### PR TITLE
add consent source field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ public
 
 .eslintrc.js
 .editorconfig
-**/.DS_Store
+*.DS_Store

--- a/demos/app.ts
+++ b/demos/app.ts
@@ -31,6 +31,7 @@ function render(
 			title,
 			formOfWords: helpers.populateConsentModel(
 				fow,
+				'n-profile-ui-demo',
 				consentRecord,
 				elementAttrs
 			),

--- a/src/js/client/consent.ts
+++ b/src/js/client/consent.ts
@@ -14,6 +14,7 @@ export class ConsentForm {
 	public element: HTMLElement;
 	public fow: string;
 	public scope: string;
+	public source: string;
 	public submitButton: HTMLButtonElement | null;
 	public radios: Array<HTMLInputElement>;
 	protected options: ConsentOptions;
@@ -30,6 +31,12 @@ export class ConsentForm {
 			throw new Error('Form of words field missing');
 		}
 		this.fow = fow;
+
+		const source = this.getValue('consentSource');
+		if (!source) {
+			throw new Error('Consent source field missing');
+		}
+		this.source = source;
 
 		this.scope = this.getValue('formOfWordsScope') || 'FTPINK';
 		this.radios = this.getRadios();
@@ -53,6 +60,6 @@ export class ConsentForm {
 
 	protected consentFromRadio(radio: HTMLInputElement): ConsentAPI.Record {
 		const consentObject = { [radio.name]: radio.value };
-		return buildConsentRecord(this.fow, consentObject, this.scope);
+		return buildConsentRecord(this.fow, consentObject, this.source);
 	}
 }

--- a/src/js/client/update-on-save.ts
+++ b/src/js/client/update-on-save.ts
@@ -22,7 +22,7 @@ export class UpdateConsentOnSave extends ConsentForm {
 			consentObject[radio.name] = radio.value;
 		});
 
-		return buildConsentRecord(this.fow, consentObject, this.scope);
+		return buildConsentRecord(this.fow, consentObject, this.source);
 	}
 
 	public checkValidity(): boolean {

--- a/src/js/helpers.ts
+++ b/src/js/helpers.ts
@@ -59,6 +59,7 @@ export function decorateChannel(
 
 export function populateConsentModel(
 	fow: FowAPI.Fow,
+	source: string,
 	consent?: ConsentAPI.Record | ConsentAPI.Channel | null,
 	elementAttrs?: Array<ElementAttr>
 ): FowAPI.Fow {
@@ -69,6 +70,7 @@ export function populateConsentModel(
 			? consent
 			: (consent[category] || {})[channel];
 
+	fow.source = source;
 	fow.consents = fow.consents.map(
 		(categoryObj: FowAPI.Category): FowAPI.Category => {
 			categoryObj.channels.forEach(
@@ -90,18 +92,15 @@ export function populateConsentModel(
 
 export function validateConsent(
 	fow: string | FowAPI.Fow,
-	scope: string,
 	category: string,
-	channel: string
+	channel: string,
+	source: string
 ): boolean {
 	// checks that the scope, category and channel
 	// match the form of words
 	// if fow is an object
 	if (typeof fow === 'string') {
 		return true;
-	}
-	if (scope !== fow.scope) {
-		throw new Error(`Scope ${scope} does not match form of words`);
 	}
 	const categoryObj = fow.consents.find(
 		categoryObj => categoryObj.category === category
@@ -121,7 +120,7 @@ export function validateConsent(
 export function buildConsentRecord(
 	fow: string | FowAPI.Fow | null,
 	keyedConsents: ConsentModelData.KeyedValues,
-	scope: string = 'FTPINK'
+	source?: string
 ): ConsentAPI.Record {
 	// builds a consent record
 	// based on a form of words, scope
@@ -139,20 +138,20 @@ export function buildConsentRecord(
 	if (!fow || !fowId) {
 		throw new Error('Missing form of words (fow) id');
 	}
-	if (!scope) {
-		throw new Error('Missing scope');
+	if (!source) {
+		throw new Error('Missing consent source');
 	}
 
 	for (let [key, value] of Object.entries(keyedConsents)) {
 		const consent = extractMetaFromString(key);
 		if (consent) {
 			const { category, channel, lbi } = consent;
-			if (validateConsent(fow, scope, category, channel)) {
+			if (validateConsent(fow, category, channel, source)) {
 				consentRecord[category] = consentRecord[category] || {};
 				consentRecord[category][channel] = {
 					status: value === 'yes',
 					lbi,
-					scope,
+					source,
 					fow: fowId
 				};
 			}

--- a/templates/consent.html
+++ b/templates/consent.html
@@ -8,6 +8,7 @@
 {{/if}}
 <input type="hidden" name="formOfWordsId" value="{{formOfWords.id}}" />
 <input type="hidden" name="formOfWordsScope" value="{{formOfWords.scope}}" />
+<input type="hidden" name="consentSource" value="{{formOfWords.source}}" />
 <div class="consent-form__intro-text">
 	{{#if formOfWords.copy.straplineSmall}}
 		{{formOfWords.copy.straplineSmall}}


### PR DESCRIPTION
 Adds a consent source field for core experience and fixes the consent schema (which, erroneously, had `scope` instead of `source`).
🐿 v2.8.0