### PR TITLE
commit the dist because bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ bower_components
 package-lock.json
 node_modules
 *.env*
-dist
 public
 
 .eslintrc.js


### PR DESCRIPTION
"Bower only includes what is committed in the repo in github"
"But you could have a post-install hook"

```json
"scripts": {
    "postinstall": "tsc"
}
```
"but that means this component would have to have typescript as a dependency, or the consumer would have to have typescript as a devDependency, and that is not a good pattern"
"Oh ok then"