### PR TITLE
add options interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-demo:
 	@$(DONE)
 
 demo: build-demo
-	npx ts-node demos/app.ts
+	ts-node demos/app.ts
 
 a11y:
 	@node .pa11yci.js

--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
 # n-profile-ui
 
-UI elements for user profile and GDPR consent:
+## Features
+
+### UI elements for user profile and GDPR consent:
 
 - whole consent form
 - individual 'yes/no' switches
 
-Isomorphic helpers for:
+### Isomorphic helpers for:
 
 - validation
 - populating the consent view
 
-Server-side helpers / examples for:
+### Server-side helpers / examples for:
 
 - retrieving forms of words
 - handling consent and consent records
+
+## Demo
+
+```sh
+make demo
+```
+
+- [Update on save](http://localhost:5005/update-on-save)
+- [Live update](http://localhost:5005/live-update)
+
+![pageshot of update-on-save 2018-04-03-1220 20](https://user-images.githubusercontent.com/12828487/38304817-98872938-3802-11e8-9831-5ed39bdc9e67.png)

--- a/demos/app.ts
+++ b/demos/app.ts
@@ -29,12 +29,12 @@ function render(
 	return function(req: Request, res: Response): void {
 		res.render(`demo-${title}`, {
 			title,
-			formOfWords: helpers.populateConsentModel(
+			formOfWords: helpers.populateConsentModel({
 				fow,
-				'n-profile-ui-demo',
-				consentRecord,
+				source: 'n-profile-ui-demo',
+				consent: consentRecord,
 				elementAttrs
-			),
+			}),
 			showHeading: true,
 			showSubmitButton: true
 		});

--- a/dist/client/consent.js
+++ b/dist/client/consent.js
@@ -1,8 +1,8 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-const helpers_1 = require('../helpers');
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const helpers_1 = require("../helpers");
 class ConsentForm {
-    constructor (opts) {
+    constructor(opts) {
         const element = document.querySelector(opts.selector);
         if (!element) {
             throw new Error('Invalid selector');
@@ -23,14 +23,14 @@ class ConsentForm {
         this.submitButton = this.element.querySelector('.consent-form__submit');
         this.options = opts;
     }
-    getValue (name) {
+    getValue(name) {
         const field = this.element.querySelector(`input[name='${name}']`);
         return field ? field.value : null;
     }
-    getRadios (checked) {
+    getRadios(checked) {
         return Array.from(this.element.querySelectorAll(`.consent-form__radio-button${checked ? ':checked' : ''}`));
     }
-    consentFromRadio (radio) {
+    consentFromRadio(radio) {
         const consentObject = { [radio.name]: radio.value };
         return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
     }

--- a/dist/client/live-update.js
+++ b/dist/client/live-update.js
@@ -1,14 +1,14 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-const consent_1 = require('./consent');
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const consent_1 = require("./consent");
 class LiveUpdateConsent extends consent_1.ConsentForm {
-    constructor (opts) {
+    constructor(opts) {
         super(opts);
         if (this.submitButton) {
             this.submitButton.style.display = 'none';
         }
     }
-    onChange (callback) {
+    onChange(callback) {
         this.radios.forEach((radio) => {
             radio.addEventListener('change', (e) => {
                 const consent = this.consentFromRadio(radio);

--- a/dist/client/main.js
+++ b/dist/client/main.js
@@ -1,8 +1,8 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-const reconsent_1 = require('./reconsent');
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const reconsent_1 = require("./reconsent");
 exports.Reconsent = reconsent_1.Reconsent;
-const live_update_1 = require('./live-update');
+const live_update_1 = require("./live-update");
 exports.LiveUpdateConsent = live_update_1.LiveUpdateConsent;
-const update_on_save_1 = require('./update-on-save');
+const update_on_save_1 = require("./update-on-save");
 exports.UpdateConsentOnSave = update_on_save_1.UpdateConsentOnSave;

--- a/dist/client/reconsent.js
+++ b/dist/client/reconsent.js
@@ -1,8 +1,8 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-const update_on_save_1 = require('./update-on-save');
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const update_on_save_1 = require("./update-on-save");
 class Reconsent extends update_on_save_1.UpdateConsentOnSave {
-    constructor (opts) {
+    constructor(opts) {
         super(opts);
         if (opts.flag === 'autoload') {
             this.overlaySetup();
@@ -11,7 +11,7 @@ class Reconsent extends update_on_save_1.UpdateConsentOnSave {
             this.bannerSetup();
         }
     }
-    bannerSetup () {
+    bannerSetup() {
         const banner = document.querySelector('.consent-banner__outer');
         const bannerButton = document.querySelector('.consent-banner__button');
         banner.classList.add('active');
@@ -20,9 +20,9 @@ class Reconsent extends update_on_save_1.UpdateConsentOnSave {
             this.overlaySetup();
         });
     }
-    overlaySetup () {
+    overlaySetup() {
     }
-    overlayCloseHandler () {
+    overlayCloseHandler() {
         const closeConsentForm = document.querySelector('.consent-form__close');
         closeConsentForm.addEventListener('click', () => {
             this.consentOverlay.close();

--- a/dist/client/update-on-save.js
+++ b/dist/client/update-on-save.js
@@ -1,9 +1,9 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-const consent_1 = require('./consent');
-const helpers_1 = require('../helpers');
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const consent_1 = require("./consent");
+const helpers_1 = require("../helpers");
 class UpdateConsentOnSave extends consent_1.ConsentForm {
-    constructor (opts) {
+    constructor(opts) {
         super(opts);
         if (this.submitButton &&
             this.options.checkValidityBeforeSubmit &&
@@ -11,7 +11,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
             this.submitButton.disabled = true;
         }
     }
-    get values () {
+    get values() {
         const radios = this.getRadios(true);
         let consentObject = {};
         radios.forEach((radio) => {
@@ -19,7 +19,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
         });
         return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
     }
-    checkValidity () {
+    checkValidity() {
         for (const radio of this.radios) {
             if (!radio.checkValidity()) {
                 return false;
@@ -27,7 +27,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
         }
         return true;
     }
-    onChange (callback) {
+    onChange(callback) {
         if (callback || this.options.checkValidityBeforeSubmit) {
             this.radios.forEach((radio) => {
                 radio.addEventListener('change', e => {
@@ -44,7 +44,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
             });
         }
     }
-    onSubmit (callback) {
+    onSubmit(callback) {
         if (this.submitButton) {
             this.submitButton.addEventListener('click', e => {
                 e.preventDefault();

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,11 +1,11 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 const Rx = /\b(lbi|consent)-(\w+)-(\w+)\b/;
-function isConsentField (name) {
+function isConsentField(name) {
     return Rx.test(name);
 }
 exports.isConsentField = isConsentField;
-function extractMetaFromString (name) {
+function extractMetaFromString(name) {
     const match = Rx.exec(name);
     if (!match) {
         return null;
@@ -19,7 +19,8 @@ function extractMetaFromString (name) {
     };
 }
 exports.extractMetaFromString = extractMetaFromString;
-function decorateChannel (fowChannel, consentChannel, elementAttrs) {
+function decorateChannel(options) {
+    let { fowChannel, consentChannel, elementAttrs } = options;
     let checkedYes = false;
     let checkedNo = false;
     if (consentChannel) {
@@ -36,19 +37,24 @@ function decorateChannel (fowChannel, consentChannel, elementAttrs) {
     });
 }
 exports.decorateChannel = decorateChannel;
-function populateConsentModel (fow, source, consent, elementAttrs) {
+function populateConsentModel(options) {
+    let { fow, source, consent, elementAttrs } = options;
     const getConsent = (category, channel) => !consent || consent.hasOwnProperty('fow')
         ? consent
         : (consent[category] || {})[channel];
     fow.source = source;
     fow.consents = fow.consents.map((categoryObj) => {
-        categoryObj.channels.map((channelObj) => decorateChannel(channelObj, getConsent(categoryObj.category, channelObj.channel), elementAttrs));
+        categoryObj.channels.map((channelObj) => decorateChannel({
+            fowChannel: channelObj,
+            consentChannel: getConsent(categoryObj.category, channelObj.channel),
+            elementAttrs
+        }));
         return categoryObj;
     });
     return fow;
 }
 exports.populateConsentModel = populateConsentModel;
-function validateConsent (fow, category, channel) {
+function validateConsent(fow, category, channel) {
     if (typeof fow === 'string') {
         return true;
     }
@@ -63,7 +69,7 @@ function validateConsent (fow, category, channel) {
     return true;
 }
 exports.validateConsent = validateConsent;
-function buildConsentRecord (fow, keyedConsents, source) {
+function buildConsentRecord(fow, keyedConsents, source) {
     let consentRecord = {};
     const { id: fowId } = typeof fow === 'string' || !fow ? { id: fow } : fow;
     if (!fow || !fowId) {

--- a/dist/server/main.js
+++ b/dist/server/main.js
@@ -1,10 +1,10 @@
-'use strict';
-Object.defineProperty(exports, '__esModule', { value: true });
-require('isomorphic-fetch');
-const helpers = require('../helpers');
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+require("isomorphic-fetch");
+const helpers = require("../helpers");
 exports.helpers = helpers;
-const n_user_api_client_1 = require('@financial-times/n-user-api-client');
-async function getFormOfWords (name, scope = 'FTPINK') {
+const n_user_api_client_1 = require("@financial-times/n-user-api-client");
+async function getFormOfWords(name, scope = 'FTPINK') {
     if (!process.env.FOW_API_HOST) {
         throw new Error('Missing FOW_API_HOST environment variable');
     }
@@ -15,12 +15,12 @@ async function getFormOfWords (name, scope = 'FTPINK') {
     return await fow.json();
 }
 exports.getFormOfWords = getFormOfWords;
-function getConsentRecord (uuid, source, mode = 'PROD', scope = 'FTPINK') {
+function getConsentRecord(uuid, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     return api.getConsentRecord();
 }
 exports.getConsentRecord = getConsentRecord;
-function saveConsent (uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
+function saveConsent(uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     const category = Object.keys(consentRecord)[0];
     const channel = Object.keys(consentRecord[category])[0];
@@ -28,12 +28,12 @@ function saveConsent (uuid, consentRecord, source, mode = 'PROD', scope = 'FTPIN
     return api.updateConsent(category, channel, consent);
 }
 exports.saveConsent = saveConsent;
-function createConsentRecord (uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
+function createConsentRecord(uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     return api.createConsentRecord(consentRecord);
 }
 exports.createConsentRecord = createConsentRecord;
-function updateConsentRecord (uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
+function updateConsentRecord(uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     return api.updateConsentRecord(consentRecord);
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@financial-times/n-internal-tool": "^2.2.4",
     "@types/express": "^4.11.1",
     "@types/isomorphic-fetch": "0.0.34",
-    "@types/node": "^9.6.1",
+    "@types/node": "^9.6.2",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
@@ -33,6 +33,7 @@
     "chalk": "^2.3.2",
     "node-sass": "^4.8.3",
     "pa11y-ci": "^2.0.1",
+    "ts-node": "^5.0.1",
     "typescript": "^2.8.1",
     "webpack": "^3.11.0"
   },
@@ -40,7 +41,7 @@
     "node": "^8.9.4"
   },
   "dependencies": {
-    "@financial-times/n-user-api-client": "^1.9.0",
+    "@financial-times/n-user-api-client": "^1.9.1",
     "isomorphic-fetch": "^2.2.1"
   }
 }

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,0 +1,12 @@
+module.exports = {
+	files: {
+		allow: [],
+		allowOverrides: []
+	},
+	strings: {
+		deny: [],
+		denyOverrides: [
+			'98872938-3802-11e8-9831-5ed39bdc9e67' // README.md:29
+		]
+	}
+};

--- a/src/js/helpers.ts
+++ b/src/js/helpers.ts
@@ -34,12 +34,22 @@ interface ElementAttr {
 	value?: string | boolean | number;
 }
 
+interface DecorateChannelArgs {
+	fowChannel: FowAPI.Channel;
+	consentChannel?: ConsentAPI.Channel;
+	elementAttrs?: Array<ElementAttr>;
+}
+
 export function decorateChannel(
-	fowChannel: FowAPI.Channel,
-	consentChannel?: ConsentAPI.Channel,
-	elementAttrs?: Array<ElementAttr>
+	options: DecorateChannelArgs
 ): ConsentModelData.Channel {
 	// adds checkedYes and checkedNo to a FoW channel object
+	let {
+		fowChannel,
+		consentChannel,
+		elementAttrs
+	 } = options;
+
 	let checkedYes: boolean = false;
 	let checkedNo: boolean = false;
 
@@ -57,14 +67,25 @@ export function decorateChannel(
 	});
 }
 
+interface PopulateConsentModelArgs {
+	fow: FowAPI.Fow;
+	source: string;
+	consent?: ConsentAPI.Record | ConsentAPI.Channel | null;
+	elementAttrs?: Array<ElementAttr>;
+}
+
 export function populateConsentModel(
-	fow: FowAPI.Fow,
-	source: string,
-	consent?: ConsentAPI.Record | ConsentAPI.Channel | null,
-	elementAttrs?: Array<ElementAttr>
+	options: PopulateConsentModelArgs
 ): FowAPI.Fow {
 	// returns a populated model for the consent view
 	// based on a FoW and a consent record or unit
+	let {
+		fow,
+		source,
+		consent,
+		elementAttrs
+	} = options;
+
 	const getConsent = (category: string, channel: string) =>
 		!consent || consent.hasOwnProperty('fow')
 			? consent
@@ -75,14 +96,14 @@ export function populateConsentModel(
 		(categoryObj: FowAPI.Category): FowAPI.Category => {
 			categoryObj.channels.map(
 				(channelObj: FowAPI.Channel): FowAPI.Channel =>
-					decorateChannel(
-						channelObj,
-						getConsent(
+					decorateChannel({
+						fowChannel: channelObj,
+						consentChannel: getConsent(
 							categoryObj.category,
 							channelObj.channel
 						),
 						elementAttrs
-					)
+					})
 			);
 			return categoryObj;
 		}


### PR DESCRIPTION
Adding an `options` interface instead of flat arguments for helper functions – improvement suggested via @remybach's [comment](https://github.com/Financial-Times/next-signup/pull/1400#discussion_r179085188)