### PR TITLE
remove margin-bottom if section is last-child

### DIFF
--- a/src/scss/buttons.scss
+++ b/src/scss/buttons.scss
@@ -1,4 +1,4 @@
-.consent-form__submit-wrapper {
+.consent-form__submit {
 	margin-top: oTypographySpacingSize(10);
 }
 

--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -24,6 +24,9 @@ $five-sixths-width: percentage(5 / 6);
 
 .consent-form__section {
 	margin-bottom: oTypographySpacingSize(8);
+	&:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .consent-form__intro-text {

--- a/templates/consent.html
+++ b/templates/consent.html
@@ -20,27 +20,29 @@
 <input type="hidden" name="consentSource" value="{{formOfWords.source}}" />
 <fieldset name="consent" class="consent-form">
 	<legend class="o-normalise-visually-hidden">Marketing consent</legend>
-	{{#each formOfWords.consents}}
-	<div class="consent-form__section">
-		{{#if isSubsection}}
-		<h3 class="consent-form__heading-level-3">
-			{{heading}}
-		</h3>
-		{{else}}
-		<h2 class="consent-form__heading-level-3">
-			{{heading}}
-		</h2>
-		{{/if}}
-		<div class="consent-form__section-label">
-			{{label}}
+	<div class="consent-form__section-wrapper">
+		{{#each formOfWords.consents}}
+		<div class="consent-form__section">
+			{{#if isSubsection}}
+			<h3 class="consent-form__heading-level-3">
+				{{heading}}
+			</h3>
+			{{else}}
+			<h2 class="consent-form__heading-level-3">
+				{{heading}}
+			</h2>
+			{{/if}}
+			<div class="consent-form__section-label">
+				{{label}}
+			</div>
+			<div class="consent-form__switches-group">
+				{{#each channels}}
+				{{>n-profile-ui/templates/yes-no-switch category=../category}}
+				{{/each}}
+			</div>
 		</div>
-		<div class="consent-form__switches-group">
-			{{#each channels}}
-			{{>n-profile-ui/templates/yes-no-switch category=../category}}
-			{{/each}}
-		</div>
+		{{/each}}
 	</div>
-	{{/each}}
 	{{#if formOfWords.copy.serviceMessagesInfo}}
 	<div class="consent-form__consent-info">
 		{{{formOfWords.copy.serviceMessagesInfo}}}


### PR DESCRIPTION
 🐿 v2.8.0 Cleans up spacing between the consent-form and the unsub-from-all section on myft-page > emails & alerts

Before:
<img width="721" alt="screen shot 2018-04-11 at 18 21 25" src="https://user-images.githubusercontent.com/17549437/38632777-9b33d22c-3db5-11e8-8990-3d7c286b6be3.png">


After:
<img width="723" alt="screen shot 2018-04-11 at 18 16 48" src="https://user-images.githubusercontent.com/17549437/38632796-ae9ac2a8-3db5-11e8-895a-4d7218e28d16.png">
