### PR TITLE
use new o-forms__inline mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "tests"
   ],
   "dependencies": {
-    "o-forms": "^5.2.5",
+    "o-forms": "^5.5.1",
     "o-buttons": "^5.11.1",
     "o-icons": "^5.6.1",
     "o-colors": "^4.2.4",

--- a/dist/client/consent.js
+++ b/dist/client/consent.js
@@ -1,8 +1,8 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const helpers_1 = require("../helpers");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const helpers_1 = require('../helpers');
 class ConsentForm {
-    constructor(opts) {
+    constructor (opts) {
         const element = document.querySelector(opts.selector);
         if (!element) {
             throw new Error('Invalid selector');
@@ -23,14 +23,14 @@ class ConsentForm {
         this.submitButton = this.element.querySelector('.consent-form__submit');
         this.options = opts;
     }
-    getValue(name) {
+    getValue (name) {
         const field = this.element.querySelector(`input[name='${name}']`);
         return field ? field.value : null;
     }
-    getRadios(checked) {
+    getRadios (checked) {
         return Array.from(this.element.querySelectorAll(`.consent-form__radio-button${checked ? ':checked' : ''}`));
     }
-    consentFromRadio(radio) {
+    consentFromRadio (radio) {
         const consentObject = { [radio.name]: radio.value };
         return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
     }

--- a/dist/client/live-update.js
+++ b/dist/client/live-update.js
@@ -1,14 +1,14 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const consent_1 = require("./consent");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const consent_1 = require('./consent');
 class LiveUpdateConsent extends consent_1.ConsentForm {
-    constructor(opts) {
+    constructor (opts) {
         super(opts);
         if (this.submitButton) {
             this.submitButton.style.display = 'none';
         }
     }
-    onChange(callback) {
+    onChange (callback) {
         this.radios.forEach((radio) => {
             radio.addEventListener('change', (e) => {
                 const consent = this.consentFromRadio(radio);

--- a/dist/client/main.js
+++ b/dist/client/main.js
@@ -1,8 +1,8 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const reconsent_1 = require("./reconsent");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const reconsent_1 = require('./reconsent');
 exports.Reconsent = reconsent_1.Reconsent;
-const live_update_1 = require("./live-update");
+const live_update_1 = require('./live-update');
 exports.LiveUpdateConsent = live_update_1.LiveUpdateConsent;
-const update_on_save_1 = require("./update-on-save");
+const update_on_save_1 = require('./update-on-save');
 exports.UpdateConsentOnSave = update_on_save_1.UpdateConsentOnSave;

--- a/dist/client/reconsent.js
+++ b/dist/client/reconsent.js
@@ -1,8 +1,8 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const update_on_save_1 = require("./update-on-save");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const update_on_save_1 = require('./update-on-save');
 class Reconsent extends update_on_save_1.UpdateConsentOnSave {
-    constructor(opts) {
+    constructor (opts) {
         super(opts);
         if (opts.flag === 'autoload') {
             this.overlaySetup();
@@ -11,7 +11,7 @@ class Reconsent extends update_on_save_1.UpdateConsentOnSave {
             this.bannerSetup();
         }
     }
-    bannerSetup() {
+    bannerSetup () {
         const banner = document.querySelector('.consent-banner__outer');
         const bannerButton = document.querySelector('.consent-banner__button');
         banner.classList.add('active');
@@ -20,9 +20,9 @@ class Reconsent extends update_on_save_1.UpdateConsentOnSave {
             this.overlaySetup();
         });
     }
-    overlaySetup() {
+    overlaySetup () {
     }
-    overlayCloseHandler() {
+    overlayCloseHandler () {
         const closeConsentForm = document.querySelector('.consent-form__close');
         closeConsentForm.addEventListener('click', () => {
             this.consentOverlay.close();

--- a/dist/client/update-on-save.js
+++ b/dist/client/update-on-save.js
@@ -1,9 +1,9 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const consent_1 = require("./consent");
-const helpers_1 = require("../helpers");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const consent_1 = require('./consent');
+const helpers_1 = require('../helpers');
 class UpdateConsentOnSave extends consent_1.ConsentForm {
-    constructor(opts) {
+    constructor (opts) {
         super(opts);
         if (this.submitButton &&
             this.options.checkValidityBeforeSubmit &&
@@ -11,7 +11,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
             this.submitButton.disabled = true;
         }
     }
-    get values() {
+    get values () {
         const radios = this.getRadios(true);
         let consentObject = {};
         radios.forEach((radio) => {
@@ -19,7 +19,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
         });
         return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
     }
-    checkValidity() {
+    checkValidity () {
         for (const radio of this.radios) {
             if (!radio.checkValidity()) {
                 return false;
@@ -27,7 +27,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
         }
         return true;
     }
-    onChange(callback) {
+    onChange (callback) {
         if (callback || this.options.checkValidityBeforeSubmit) {
             this.radios.forEach((radio) => {
                 radio.addEventListener('change', e => {
@@ -44,7 +44,7 @@ class UpdateConsentOnSave extends consent_1.ConsentForm {
             });
         }
     }
-    onSubmit(callback) {
+    onSubmit (callback) {
         if (this.submitButton) {
             this.submitButton.addEventListener('click', e => {
                 e.preventDefault();

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,11 +1,11 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
 const Rx = /\b(lbi|consent)-(\w+)-(\w+)\b/;
-function isConsentField(name) {
+function isConsentField (name) {
     return Rx.test(name);
 }
 exports.isConsentField = isConsentField;
-function extractMetaFromString(name) {
+function extractMetaFromString (name) {
     const match = Rx.exec(name);
     if (!match) {
         return null;
@@ -19,7 +19,7 @@ function extractMetaFromString(name) {
     };
 }
 exports.extractMetaFromString = extractMetaFromString;
-function decorateChannel(options) {
+function decorateChannel (options) {
     let { fowChannel, consentChannel, elementAttrs } = options;
     let checkedYes = false;
     let checkedNo = false;
@@ -37,7 +37,7 @@ function decorateChannel(options) {
     });
 }
 exports.decorateChannel = decorateChannel;
-function populateConsentModel(options) {
+function populateConsentModel (options) {
     let { fow, source, consent, elementAttrs } = options;
     const getConsent = (category, channel) => !consent || consent.hasOwnProperty('fow')
         ? consent
@@ -54,7 +54,7 @@ function populateConsentModel(options) {
     return fow;
 }
 exports.populateConsentModel = populateConsentModel;
-function validateConsent(fow, category, channel) {
+function validateConsent (fow, category, channel) {
     if (typeof fow === 'string') {
         return true;
     }
@@ -69,7 +69,7 @@ function validateConsent(fow, category, channel) {
     return true;
 }
 exports.validateConsent = validateConsent;
-function buildConsentRecord(fow, keyedConsents, source) {
+function buildConsentRecord (fow, keyedConsents, source) {
     let consentRecord;
     const { id: fowId } = typeof fow === 'string' || !fow ? { id: fow } : fow;
     if (!fow || !fowId) {

--- a/dist/server/main.js
+++ b/dist/server/main.js
@@ -1,10 +1,10 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-require("isomorphic-fetch");
-const helpers = require("../helpers");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+require('isomorphic-fetch');
+const helpers = require('../helpers');
 exports.helpers = helpers;
-const n_user_api_client_1 = require("@financial-times/n-user-api-client");
-async function getFormOfWords(name, scope = 'FTPINK') {
+const n_user_api_client_1 = require('@financial-times/n-user-api-client');
+async function getFormOfWords (name, scope = 'FTPINK') {
     if (!process.env.FOW_API_HOST) {
         throw new Error('Missing FOW_API_HOST environment variable');
     }
@@ -15,12 +15,12 @@ async function getFormOfWords(name, scope = 'FTPINK') {
     return await fow.json();
 }
 exports.getFormOfWords = getFormOfWords;
-function getConsentRecord(uuid, source, mode = 'PROD', scope = 'FTPINK') {
+function getConsentRecord (uuid, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     return api.getConsentRecord();
 }
 exports.getConsentRecord = getConsentRecord;
-function saveConsent(uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
+function saveConsent (uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     const category = Object.keys(consentRecord)[0];
     const channel = Object.keys(consentRecord[category])[0];
@@ -28,12 +28,12 @@ function saveConsent(uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK
     return api.updateConsent(category, channel, consent);
 }
 exports.saveConsent = saveConsent;
-function createConsentRecord(uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
+function createConsentRecord (uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     return api.createConsentRecord(consentRecord);
 }
 exports.createConsentRecord = createConsentRecord;
-function updateConsentRecord(uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
+function updateConsentRecord (uuid, consentRecord, source, mode = 'PROD', scope = 'FTPINK') {
     const api = new n_user_api_client_1.UserConsent(uuid, source, mode, scope);
     return api.updateConsentRecord(consentRecord);
 }

--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -1,6 +1,7 @@
 @include oFormsBaseFeatures($class: 'consent-form');
 @include oFormsRadioCheckboxFeatures($class: 'consent-form');
 @include oFormsRadioButtonsStyledFeature($class: 'consent-form');
+@include oFormsInlineFeature($class: 'consent-form');
 
 $five-sixths-width: percentage(5 / 6);
 
@@ -9,13 +10,11 @@ $five-sixths-width: percentage(5 / 6);
 }
 
 .consent-form {
-	@include oTypographySans($scale: 0);
-	margin-bottom: 0;
-	margin-left: auto;
-	margin-right: auto;
-	padding-left: 0;
-	padding-right: 0;
 	max-width: none;
+}
+
+.consent-form__group {
+	margin-left: auto;
 }
 
 .consent-form--scrollable {
@@ -62,21 +61,6 @@ $five-sixths-width: percentage(5 / 6);
 	margin-bottom: oTypographySpacingSize(5);
 	&:last-child {
 		margin-bottom: 0;
-	}
-}
-
-.consent-form__inline-wrapper {
-	@include oGridRespondTo(M) {
-		align-items: center;
-		justify-content: space-between;
-		display: flex;
-		flex-wrap: wrap;
-	}
-	.consent-form__group {
-		margin-bottom: 0;
-	}
-	.consent-form__group input + .consent-form__label {
-		margin: 0;
 	}
 }
 

--- a/templates/yes-no-switch.html
+++ b/templates/yes-no-switch.html
@@ -1,20 +1,16 @@
 <fieldset class="consent-form consent-form--inline">
-	<div class="consent-form__inline-wrapper">
-		<div>
-			<legend class="consent-form__label" id="legend-{{{category}}}-{{{channel}}}">{{label}}</legend>
-		</div>
+	<div class="consent-form__inline-container">
+		<legend class="consent-form__label" id="legend-{{{category}}}-{{{channel}}}">{{label}}</legend>
 		{{#if description}}
 		<div class="consent-form__item-description">
 			{{description}}
 		</div>
 		{{/if}}
-		<div>
-			<div class="consent-form__group consent-form__group--inline-together">
-				<input type="radio" name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}" value="yes" class="consent-form__radio-button{{#if inputClass}} {{inputClass}}{{/if}}" id="{{{category}}}-{{{channel}}}-yes" aria-describedby="legend-{{{category}}}-{{{channel}}}" data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-yes"{{#if checkedYes}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}} />
-				<label for="{{{category}}}-{{{channel}}}-yes" class="consent-form__label">Yes</label>
-				<input type="radio" name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}" value="no" class="consent-form__radio-button consent-form__radio-button--negative" id="{{{category}}}-{{{channel}}}-no" aria-describedby="legend-{{{category}}}-{{{channel}}}" data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-no"{{#if checkedNo}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}} />
-				<label for="{{{category}}}-{{{channel}}}-no" class="consent-form__label">No</label>
-			</div>
+		<div class="consent-form__group consent-form__group--inline-together">
+			<input type="radio" name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}" value="yes" class="consent-form__radio-button{{#if inputClass}} {{inputClass}}{{/if}}" id="{{{category}}}-{{{channel}}}-yes" aria-describedby="legend-{{{category}}}-{{{channel}}}" data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-yes"{{#if checkedYes}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}} />
+			<label for="{{{category}}}-{{{channel}}}-yes" class="consent-form__label">Yes</label>
+			<input type="radio" name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}" value="no" class="consent-form__radio-button consent-form__radio-button--negative" id="{{{category}}}-{{{channel}}}-no" aria-describedby="legend-{{{category}}}-{{{channel}}}" data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-no"{{#if checkedNo}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}} />
+			<label for="{{{category}}}-{{{channel}}}-no" class="consent-form__label">No</label>
 		</div>
 	</div>
 	{{#if advisory}}


### PR DESCRIPTION
 🐿 v2.8.0 The latest o-forms release overwrote some consent-form styles. To fix, I've removed some custom code and pulled in the new `__inline` styles from o-forms. 
( So many dist changes 🙈 )

Before:
<img width="736" alt="screen shot 2018-04-18 at 21 16 36" src="https://user-images.githubusercontent.com/17549437/38955902-db2a5b7e-434d-11e8-87ca-0fb7fbd35c50.png">

After:
<img width="737" alt="screen shot 2018-04-18 at 21 19 11" src="https://user-images.githubusercontent.com/17549437/38955983-2e717d76-434e-11e8-8ee0-de136056e08d.png">

Total aside, but I found this https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self which we can't use yet (because polyfill?) but Chrome have implemented and omw I want it! 🎉 ❤️