### PR TITLE
Split CSS for 'subheading' component; use external link from o-typography

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "o-buttons": "^5.11.1",
     "o-icons": "^5.6.1",
     "o-colors": "^4.2.4",
-    "o-typography": "^5.6.0",
+    "o-typography": "^5.6.2",
     "o-expander": "^4.4.4",
     "o-overlay": "^2.4.1",
     "o-banner": "^1.5.0",

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -10,3 +10,4 @@
 @import './buttons';
 @import './message';
 @import './layout';
+@import './subheading';

--- a/src/scss/subheading.scss
+++ b/src/scss/subheading.scss
@@ -1,0 +1,16 @@
+.subheading {
+	@include oTeaserCollectionHeadingBorderTypography;
+	padding-top: oTypographySpacingSize(4);
+}
+
+.subheading__title {
+	@include oTypographyProductHeadingLevel5;
+	@include oTypographyBold(sans);
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+.subheading__link {
+	@include oTypographyLinkExternal;
+	@include oTypographySans(0);
+}

--- a/src/scss/typography.scss
+++ b/src/scss/typography.scss
@@ -1,8 +1,3 @@
-.heading-bar {
-	@include oTeaserCollectionHeadingBorderTypography;
-	padding-top: oTypographySpacingSize(4);
-}
-
 .consent-form__heading-level-1 {
 	@include oTypographyProductHeadingLevel3;
 	margin-bottom: oTypographySpacingSize(1);
@@ -11,13 +6,6 @@
 .consent-form__heading-strapline {
 	display: block;
 	font-weight: 400;
-}
-
-.consent-form__heading-level-2 {
-	@include oTypographyProductHeadingLevel5;
-	@include oTypographyBold(sans);
-	margin-top: 0;
-	margin-bottom: 0;
 }
 
 .consent-form__heading-level-3 {
@@ -32,20 +20,4 @@
 	padding-top: oTypographySpacingSize(4);
 	border-top: 1px solid oColorsGetPaletteColor('black-30');
 	margin-bottom: oTypographySpacingSize(1);
-}
-
-.link-external {
-	@include oTypographyLink;
-	@include oTypographySans(0);
-	margin-right: oTypographySpacingSize(6);
-	position: relative;
-	&::after {
-		@include oIconsGetIcon('outside-page', oColorsGetPaletteColor('teal'), 24);
-		content: '';
-		display: block;
-		position: absolute;
-		right: oTypographySpacingSize(6) * -1;
-		top: 50%;
-		transform: translateY(-50%);
-	}
 }

--- a/templates/subheading.html
+++ b/templates/subheading.html
@@ -1,10 +1,10 @@
-<div class="consent-row consent-row--align-baseline{{#ifEquals linkAlign 'right'}} consent-row--justify-between{{/ifEquals}} heading-bar heading-bar--full-width">
-	<h2 class="consent-row__cell-grow consent-form__heading-level-2">
+<div class="consent-row consent-row--align-baseline{{#ifEquals linkAlign 'right'}} consent-row--justify-between{{/ifEquals}} subheading subheading--full-width">
+	<h2 class="consent-row__cell-grow subheading__title">
 		{{{text}}}
 	</h2>
 	{{#unless hideLink}}
 	<div>
-		<a class="link-external" href="{{linkUrl}}" target="_blank" rel="noopener" aria-label="{{linkAriaLabel}}" data-trackable="{{trackable}}">{{linkText}}</a>
+		<a class="subheading__link" href="{{linkUrl}}" target="_blank" rel="noopener" aria-label="{{linkAriaLabel}}" data-trackable="{{trackable}}">{{linkText}}</a>
 	</div>
 	{{/unless}}
 </div>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/471250/38984386-702a8ae4-43be-11e8-8fef-edfec42a412a.png)


 🐿 v2.8.0