### PR TITLE
Use new inline controls option

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "tests"
   ],
   "dependencies": {
-    "o-forms": "^5.5.1",
+    "o-forms": "^5.6.0",
     "o-buttons": "^5.11.2",
     "o-icons": "^5.6.1",
     "o-colors": "^4.3.1",

--- a/templates/yes-no-switch.html
+++ b/templates/yes-no-switch.html
@@ -1,4 +1,4 @@
-<fieldset class="consent-form consent-form--inline">
+<fieldset class="consent-form consent-form--inline-controls">
 	<div class="consent-form__inline-container">
 		<legend class="consent-form__label" id="legend-{{{category}}}-{{{channel}}}">{{label}}</legend>
 		{{#if description}}

--- a/templates/yes-no-switch.html
+++ b/templates/yes-no-switch.html
@@ -1,4 +1,4 @@
-<fieldset class="consent-form consent-form--inline-controls">
+<fieldset class="consent-form consent-form--inline">
 	<div class="consent-form__inline-container">
 		<legend class="consent-form__label" id="legend-{{{category}}}-{{{channel}}}">{{label}}</legend>
 		{{#if description}}


### PR DESCRIPTION
Update to use the new `consent-form--inline-controls` class (Thanks @notlee !)

Before:
<img width="388" alt="screen shot 2018-04-27 at 09 37 54" src="https://user-images.githubusercontent.com/17549437/39353195-df45a7c4-49fe-11e8-869f-0d38b4108420.png">

Afrer:
<img width="389" alt="screen shot 2018-04-27 at 09 31 26" src="https://user-images.githubusercontent.com/17549437/39353204-e4ac1824-49fe-11e8-8422-7ce57d2a25f4.png">
