### PR TITLE
Fix cookie parser; expect string status from live update callback

### DIFF
--- a/dist/commonjs/client/live-update.js
+++ b/dist/commonjs/client/live-update.js
@@ -44,11 +44,11 @@ class LiveUpdateConsent extends consent_1.ConsentForm {
 				if (radioWrapper) {
 					radioWrapper.classList.remove('consent-form--saved');
 					callback(consent, e)
-						.then(response => {
-							if (response.status < 400) {
+						.then(result => {
+							if (result === 'success') {
 								return this.saveSuccess(radioWrapper);
 							}
-							if (response.status === 403) {
+							if (result === 'redirect') {
 								return this.redirect();
 							}
 							this.saveFail(radioWrapper);

--- a/dist/commonjs/helpers.js
+++ b/dist/commonjs/helpers.js
@@ -124,7 +124,7 @@ function updateConsentCookie (consent, cookieOptions = {
 }
 exports.updateConsentCookie = updateConsentCookie;
 function parseConsentCookie (name) {
-	const rx = new RegExp(`${name}=(.*?);`);
+	const rx = new RegExp(`${name}=([^;]*)`);
 	const matched = document.cookie.match(rx);
 	if (!matched) {
 		return null;

--- a/dist/esm/client/live-update.js
+++ b/dist/esm/client/live-update.js
@@ -42,11 +42,11 @@ export class LiveUpdateConsent extends ConsentForm {
 				if (radioWrapper) {
 					radioWrapper.classList.remove('consent-form--saved');
 					callback(consent, e)
-						.then(response => {
-							if (response.status < 400) {
+						.then(result => {
+							if (result === 'success') {
 								return this.saveSuccess(radioWrapper);
 							}
-							if (response.status === 403) {
+							if (result === 'redirect') {
 								return this.redirect();
 							}
 							this.saveFail(radioWrapper);

--- a/dist/esm/helpers.js
+++ b/dist/esm/helpers.js
@@ -115,7 +115,7 @@ export function updateConsentCookie (consent, cookieOptions = {
 	document.cookie = cookie.join('; ');
 }
 function parseConsentCookie (name) {
-	const rx = new RegExp(`${name}=(.*?);`);
+	const rx = new RegExp(`${name}=([^;]*)`);
 	const matched = document.cookie.match(rx);
 	if (!matched) {
 		return null;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "precommit": "make build-for-commit && node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "commit": "commit-wizard",
-    "prepush": "make verify-with-tslint -j3"
+    "prepush": "make test verify-with-tslint -j3"
   },
   "repository": {
     "type": "git",

--- a/src/js/client/live-update.ts
+++ b/src/js/client/live-update.ts
@@ -50,11 +50,11 @@ export class LiveUpdateConsent extends ConsentForm {
 				if (radioWrapper) {
 					radioWrapper.classList.remove('consent-form--saved');
 					callback(consent, e)
-						.then(response => {
-							if (response.status < 400) {
+						.then(result => {
+							if (result === 'success') {
 								return this.saveSuccess(radioWrapper);
 							}
-							if (response.status === 403) {
+							if (result === 'redirect') {
 								return this.redirect();
 							}
 							this.saveFail(radioWrapper);

--- a/src/js/helpers.ts
+++ b/src/js/helpers.ts
@@ -221,7 +221,7 @@ interface UnmarshalledCookie {
 }
 
 function parseConsentCookie(name: string): UnmarshalledCookie | null {
-	const rx = new RegExp(`${name}=(.*?);`);
+	const rx = new RegExp(`${name}=([^;]*)`);
 	const matched = document.cookie.match(rx);
 
 	if (!matched) {

--- a/test/client/helpers/init-consent-form.ts
+++ b/test/client/helpers/init-consent-form.ts
@@ -26,6 +26,15 @@ export default function (callback) {
 			body: JSON.stringify({
 				data: consent
 			})
+		})
+		.then(response => {
+			if (response.status < 400) {
+				return 'success';
+			}
+			if (response.status === 403) {
+				return 'redirect';
+			}
+			return 'fail';
 		});
 	});
 };


### PR DESCRIPTION
 🐿 v2.8.0