### PR TITLE
Add subheading levels 2 & 3

### DIFF
--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -118,6 +118,7 @@ $two-thirds-width: percentage(2 / 3);
 .consent-form__item-advisory-para {
 	margin-top: 0;
 	&:last-child {
+		margin-top: oTypographySpacingSize(3);
 		margin-bottom: 0;
 	}
 }

--- a/src/scss/subheading.scss
+++ b/src/scss/subheading.scss
@@ -3,7 +3,8 @@
 	padding-top: oTypographySpacingSize(4);
 }
 
-.subheading--minor {
+.subheading--level-2,
+.subheading--level-3 {
 	padding-top: oTypographySpacingSize(2);
 }
 
@@ -12,7 +13,13 @@
 	@include oTypographyBold(sans);
 	margin-top: 0;
 	margin-bottom: 0;
-	.subheading--minor & {
+	.subheading--level-2 & {
+		@include oTypographyProductHeadingLevel6;
+		@include oTypographyBold(sans);
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+	.subheading--level-3 & {
 		@include oTypographyProductHeadingLevel7;
 		@include oTypographyBold(sans);
 		margin-top: 0;
@@ -25,7 +32,9 @@
 	@include oTypographySans(0);
 }
 
-.subheading--minor:before,
-.subheading--minor:after {
+.subheading--level-2:before,
+.subheading--level-2:after,
+.subheading--level-3:before,
+.subheading--level-3:after{
 	border-top-width: 1px;
 }

--- a/templates/subheading.html
+++ b/templates/subheading.html
@@ -1,4 +1,4 @@
-<div class="flex-row flex-row--align-baseline{{#ifEquals linkAlign 'right'}} flex-row--justify-between{{/ifEquals}} subheading subheading--full-width{{#if minorSubheading}} subheading--minor{{/if}}">
+<div class="flex-row flex-row--align-baseline{{#ifEquals linkAlign 'right'}} flex-row--justify-between{{/ifEquals}} subheading subheading--full-width{{#if subheadingLevel}} subheading--level-{{subheadingLevel}}{{/if}}">
 	<h2 class="flex-row__cell-grow subheading__title">
 		{{{text}}}
 	</h2>


### PR DESCRIPTION
Support 3 levels of subheading so the 'thin border' style can have 2 different font sizes

![image](https://user-images.githubusercontent.com/471250/41167876-1bd1a9a0-6b3c-11e8-96ec-83c20532678a.png)

 🐿 v2.8.0