### PR TITLE
Additional configuration for settings page

### DIFF
--- a/templates/components/yes-no-switch.html
+++ b/templates/components/yes-no-switch.html
@@ -11,9 +11,21 @@
 		</div>
 		<div class="consent-form__group consent-form__group--inline-together">
 			<input type="radio" name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}" value="yes" class="consent-form__radio-button{{#if inputClass}} {{inputClass}}{{/if}}" id="{{{category}}}-{{{channel}}}-yes" aria-describedby="legend-{{{category}}}-{{{channel}}}" data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-yes"{{#if checkedYes}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}} />
-			<label for="{{{category}}}-{{{channel}}}-yes" class="consent-form__label">Yes</label>
+			<label for="{{{category}}}-{{{channel}}}-yes" class="consent-form__label">
+				{{#if toggleOnLabel}}
+					{{toggleOnLabel}}
+				{{else}}
+					Yes
+				{{/if}}
+			</label>
 			<input type="radio" name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}" value="no" class="consent-form__radio-button consent-form__radio-button--negative" id="{{{category}}}-{{{channel}}}-no" aria-describedby="legend-{{{category}}}-{{{channel}}}" data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-no"{{#if checkedNo}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}} />
-			<label for="{{{category}}}-{{{channel}}}-no" class="consent-form__label">No</label>
+			<label for="{{{category}}}-{{{channel}}}-no" class="consent-form__label">
+				{{#if toggleOffLabel}}
+					{{toggleOffLabel}}
+				{{else}}
+					No
+				{{/if}}
+			</label>
 		</div>
 		<div class="consent-form__status" aria-hidden="false" aria-live="polite"></div>
 		<div class="consent-form__errortext">There was a problem saving, please try later.</div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -30,7 +30,11 @@
 			subheadingLevel=subheadingLevel}}
 		<div>
 			{{#each channels}}
-			{{>n-profile-ui/templates/components/yes-no-switch category=../category}}
+			{{>n-profile-ui/templates/components/yes-no-switch
+				category=../category
+				toggleOnLabel=../../toggleOnLabel
+				toggleOffLabel=../../toggleOffLabel
+			}}
 			{{/each}}
 		</div>
 	</div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -42,15 +42,17 @@
 	{{#if formOfWords.copy.submitPreamble}}
 	{{{formOfWords.copy.submitPreamble}}}
 	{{/if}}
-	{{#unless formOfWords.error}}
-	<div class="consent-form__submit-wrapper">
-		<button type="submit" class="consent-form__submit" data-trackable="manage-cookies-accept">
-			{{#if formOfWords.copy.submitButton}}
-			{{{formOfWords.copy.submitButton}}}
-			{{else}}
-			Confirm
-			{{/if}}
-		</button>
-	</div>
-	{{/unless}}
+	{{#if showSubmitButton}}
+		{{#unless formOfWords.error}}
+		<div class="consent-form__submit-wrapper">
+			<button type="submit" class="consent-form__submit">
+				{{#if formOfWords.copy.submitButton}}
+				{{{formOfWords.copy.submitButton}}}
+				{{else}}
+				Confirm
+				{{/if}}
+			</button>
+		</div>
+		{{/unless}}
+	{{/if}}
 </div>


### PR DESCRIPTION
Add config options to:

* Change the labels on the consent toggles
* Hide/show the submit button on the settings page

I think the settings partial should probably be moved into next-control-centre. It's not being used by any other application and it's use-case is pretty specific to the control centre.