### PR TITLE
Upgrade TypeScript version + specific types to compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ts-jest": "^22.4.5",
     "ts-node": "^6.0.3",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3",
+    "typescript": "^3.7.2",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.1"
   },

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -14,6 +14,33 @@
     "strict": true,
     "removeComments": true,
     "lib": ["es2017", "dom"],
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "types": [
+      "agent-base",
+      "body-parser",
+      "bunyan",
+      "connect",
+      "debug",
+      "events",
+      "express",
+      "express-serve-static-core",
+      "glob",
+      "handlebars",
+      "isomorphic-fetch",
+      "jest",
+      "js-yaml",
+      "mime",
+      "minimatch",
+      "node",
+      "normalize-package-data",
+      "range-parser",
+      "restify",
+      "semver",
+      "serve-static",
+      "sinon",
+      "unist",
+      "vfile-message",
+      "xml2js"
+    ]
   }
 }


### PR DESCRIPTION
The build currently fails owing to `error TS2304: Cannot find name 'unknown'.` (seen [here](https://circleci.com/gh/Financial-Times/n-profile-ui/1315)).

Fixing this by upgrading from TypeScript v2 -> v3 will then result in `error TS2307: Cannot find module 'vfile-message'` (from `import * as vfileMessage from 'vfile-message';`), which arises because this repo has the following npm dependencies:

`n-profile-ui`
-> `n-gage`
-> `stylelint`
-> `postcss-markdown` (**unmaintained and needs to bump its `remark` dependency v10 -> v11**)
-> `remark`
-> `unified`
-> `vfile`

Requests have been made to the collaborators of the `postcss-markdown` package to release a version with its `remark` dependency upgraded, but only one of them has the required access to npm and they have been absent since the request was made on 26 Oct 2019.

In the meantime, it seems the simplest solution is to exclude `vfile-message` from the compiled types. There is no 'exclude' option for applying this selection, so this PR includes all types except for the problematic one.

#### References:
- [GitHub - gucong3000/postcss-markdown - Pull requests: feat: update remark version to v11](https://github.com/gucong3000/postcss-markdown/pull/33).
- [GitHub - gucong3000/postcss-markdown - Issues: Update remark to v11](https://github.com/gucong3000/postcss-markdown/issues/31).
- [GitHub - gucong3000/postcss-markdown - Issues: upgrade remark to v11 to fix declaration error](https://github.com/gucong3000/postcss-markdown/issues/32).
- [GitHub - stylelint/stylelint - Issue: Downgrade `postcss-markdown` to 0.34 or increase the mayor version](https://github.com/stylelint/stylelint/issues/3907).
- [TypeScript - tsconfig.json: `@types`, `typeRoots` and `types`](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).