### PR TITLE
overwrite o-forms flex for consent-forms

### DIFF
--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -60,6 +60,14 @@ $two-thirds-width: percentage(2 / 3);
 			.o-forms-input {
 				align-items: flex-end;
 			}
+
+			.o-forms-input {
+				flex: initial;
+			}
+
+			.o-forms-title {
+				flex: 1 0 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
Make consent forms have wider title text because the inputs are all the same width and having a small title section causes the tetx to wrap too much