### PR TITLE
remove o-teaser-collection because it is for editorial content and not for product content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     "o-icons": "^6.0.0",
     "o-message": "^4.0.0",
     "o-overlay": "^3.0.0",
-    "o-teaser-collection": "^3.0.0",
     "o-typography": "^6.0.0"
   }
 }

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -3,7 +3,6 @@
 @import 'o-forms/main';
 @import 'o-icons/main';
 @import 'o-buttons/main';
-@import 'o-teaser-collection/main';
 
 @import './components/alert-message';
 

--- a/src/scss/subheading.scss
+++ b/src/scss/subheading.scss
@@ -1,5 +1,27 @@
 .subheading {
-	@include oTeaserCollectionContentHeading();
+	@include oTypographySans(3, $weight: 'regular');
+	position: relative;
+	margin: 0;
+	padding-top: oSpacingByName('s3');
+	padding-bottom: oSpacingByName('s4');
+
+	&:before,
+	&:after {
+		border-top: 1px solid rgba(oColorsByName('black'), 0.05);
+		content: '';
+		left: 0;
+		top: 0;
+		position: absolute;
+		width: 100%;
+	}
+
+	&:after {
+		border-top-color: oColorsByName('black');
+
+		@include oGridRespondTo(L) {
+			width: 32.5%;
+		}
+	}
 	padding-top: oSpacingByName('s1');
 }
 

--- a/templates/subheading.html
+++ b/templates/subheading.html
@@ -1,4 +1,4 @@
-<div class="flex-row flex-row--align-baseline{{#ifEquals linkAlign 'right'}} flex-row--justify-between{{/ifEquals}} subheading subheading--full-width{{#if subheadingLevel}} subheading--level-{{subheadingLevel}}{{/if}}">
+<div class="flex-row flex-row--align-baseline{{#ifEquals linkAlign 'right'}} flex-row--justify-between{{/ifEquals}} subheading {{#if subheadingLevel}} subheading--level-{{subheadingLevel}}{{/if}}">
 	<h2 class="flex-row__cell-grow subheading__title">
 		{{{text}}}
 	</h2>


### PR DESCRIPTION
This piece of work is required to unblock https://github.com/Financial-Times/next-control-centre in the origami cascade work