### PR TITLE
Restore consent information padding and background

### DIFF
--- a/demos/fixtures/fow.json
+++ b/demos/fixtures/fow.json
@@ -2,7 +2,8 @@
   "copy": {
     "heading1": "We're improving how you stay up to date with the FT.",
     "straplineHeading": "Choose how we contact you.",
-    "straplineSmall": "Strapline small text."
+    "straplineSmall": "Strapline small text.",
+    "serviceMessagesInfo": "<div class=\"consent-form__consent-info-para\">We’ll still send you service messages about your account, security or legal notifications.</div><div class=\"consent-form__consent-info-para\">For more information about how we use your data, please refer to our <a class=\"consent-form__link--external\" href=\"http://help.ft.com/help/legal-privacy/privacy/\" target=\"_blank\">privacy</a> and <a class=\"consent-form__link--external\" href=\"http://help.ft.com/help/legal-privacy/cookies/\" target=\"_blank\">cookie</a> policies.</div>"
   },
   "consents": [
     {

--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -78,3 +78,19 @@ $two-thirds-width: percentage(2 / 3);
 .consent-form-content {
 	background-color: oColorsByName('paper');
 }
+
+.consent-form__consent-info {
+	background-color: oColorsByName('wheat');
+	padding-left: oSpacingByName('s4');
+	padding-right: oSpacingByName('s4');
+	padding-top: oSpacingByName('s3');
+	padding-bottom: oSpacingByName('s3');
+}
+
+.consent-form__consent-info-para {
+	margin-bottom: oSpacingByName('s3');
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+}


### PR DESCRIPTION
## Description
When updating `n-profile-ui` in `next-profile` we lost the background and padding for the consent information displayed above the submit button:

![image](https://user-images.githubusercontent.com/6975428/70712586-0033d080-1cdc-11ea-8ab9-39bfdda80ef8.png)

Turns out this was because it wasn't displayed in the demos for `n-profile-ui` and so the styling was removed.

This PR adds that messaging into the demo, and restores that styling.

**Before**
![image](https://user-images.githubusercontent.com/6975428/70712456-bd71f880-1cdb-11ea-8eea-35b60d4f96bc.png)

**After**
![image](https://user-images.githubusercontent.com/6975428/70712290-5fddac00-1cdb-11ea-9462-3dd206a0b6f4.png)

