### PR TITLE
Origami fixes

### DIFF
--- a/dist/commonjs/client/consent.js
+++ b/dist/commonjs/client/consent.js
@@ -1,38 +1,38 @@
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const helpers_1 = require("../helpers");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const helpers_1 = require('../helpers');
 class ConsentForm {
-    constructor(opts) {
-        const element = document.querySelector(opts.selector);
-        if (!element) {
-            throw new Error('Invalid selector');
-        }
-        this.element = element;
-        const fow = this.getValue('formOfWordsId');
-        if (!fow) {
-            throw new Error('Form of words field missing');
-        }
-        this.fow = fow;
-        const source = this.getValue('consentSource');
-        if (!source) {
-            throw new Error('Consent source field missing');
-        }
-        this.source = source;
-        this.scope = this.getValue('formOfWordsScope') || 'FTPINK';
-        this.radios = this.getRadios();
-        this.submitButton = this.element.querySelector('.consent-form__submit');
-        this.options = opts;
-    }
-    getValue(name) {
-        const field = this.element.querySelector(`input[name='${name}']`);
-        return field ? field.value : null;
-    }
-    getRadios(checked) {
-        return Array.from(this.element.querySelectorAll(`.consent-form__radio-button${checked ? ':checked' : ''}`));
-    }
-    consentFromRadio(radio) {
-        const consentObject = { [radio.name]: radio.value };
-        return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
-    }
+	constructor (opts) {
+		const element = document.querySelector(opts.selector);
+		if (!element) {
+			throw new Error('Invalid selector');
+		}
+		this.element = element;
+		const fow = this.getValue('formOfWordsId');
+		if (!fow) {
+			throw new Error('Form of words field missing');
+		}
+		this.fow = fow;
+		const source = this.getValue('consentSource');
+		if (!source) {
+			throw new Error('Consent source field missing');
+		}
+		this.source = source;
+		this.scope = this.getValue('formOfWordsScope') || 'FTPINK';
+		this.radios = this.getRadios();
+		this.submitButton = this.element.querySelector('.consent-form__submit');
+		this.options = opts;
+	}
+	getValue (name) {
+		const field = this.element.querySelector(`input[name='${name}']`);
+		return field ? field.value : null;
+	}
+	getRadios (checked) {
+		return Array.from(this.element.querySelectorAll(`.consent-form__radio-button${checked ? ':checked' : ''}`));
+	}
+	consentFromRadio (radio) {
+		const consentObject = { [radio.name]: radio.value };
+		return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
+	}
 }
 exports.ConsentForm = ConsentForm;

--- a/dist/commonjs/client/live-update.js
+++ b/dist/commonjs/client/live-update.js
@@ -1,67 +1,67 @@
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const consent_1 = require("./consent");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const consent_1 = require('./consent');
 class LiveUpdateConsent extends consent_1.ConsentForm {
-    constructor(opts) {
-        super(opts);
-        if (this.submitButton) {
-            this.submitButton.style.display = 'none';
-        }
-    }
-    saveSuccess(radioWrapper) {
-        if (radioWrapper) {
-            radioWrapper.classList.remove('o-forms-input--error');
-            radioWrapper.classList.remove('o-forms-input--saving');
-            radioWrapper.classList.add('o-forms-input--saved');
-        }
-        this.savedEvent({ success: true });
-    }
-    saveFail(radioWrapper) {
-        if (radioWrapper) {
-            radioWrapper.classList.remove('o-forms-input--saving');
-            radioWrapper.classList.add('o-forms-input--error');
-            const unchecked = radioWrapper.querySelector('.o-forms-input__radio-button:not(:checked)');
-            if (unchecked) {
-                unchecked.checked = true;
-            }
-        }
-        this.savedEvent({ success: false });
-    }
-    redirect() {
-        window.location.assign(`/login${document.referrer ? `?location=${document.referrer}` : ''}`);
-    }
-    savedEvent({ success }) {
-        const event = new CustomEvent('consent-form:saved', {
-            detail: {
-                success
-            }
-        });
-        this.element.dispatchEvent(event);
-    }
-    onChange(callback) {
-        this.radios.forEach((radio) => {
-            radio.addEventListener('change', (e) => {
-                const consent = this.consentFromRadio(radio);
-                const radioWrapper = radio.closest('.o-forms-input');
-                if (radioWrapper) {
-                    radioWrapper.classList.add('o-forms-input--saving');
-                    radioWrapper.classList.remove('o-forms-input--saved');
-                    callback(consent, e)
-                        .then(result => {
-                        if (result === 'success') {
-                            return this.saveSuccess(radioWrapper);
-                        }
-                        if (result === 'redirect') {
-                            return this.redirect();
-                        }
-                        this.saveFail(radioWrapper);
-                    })
-                        .catch(() => {
-                        this.saveFail(radioWrapper);
-                    });
-                }
-            });
-        });
-    }
+	constructor (opts) {
+		super(opts);
+		if (this.submitButton) {
+			this.submitButton.style.display = 'none';
+		}
+	}
+	saveSuccess (radioWrapper) {
+		if (radioWrapper) {
+			radioWrapper.classList.remove('o-forms-input--error');
+			radioWrapper.classList.remove('o-forms-input--saving');
+			radioWrapper.classList.add('o-forms-input--saved');
+		}
+		this.savedEvent({ success: true });
+	}
+	saveFail (radioWrapper) {
+		if (radioWrapper) {
+			radioWrapper.classList.remove('o-forms-input--saving');
+			radioWrapper.classList.add('o-forms-input--error');
+			const unchecked = radioWrapper.querySelector('.o-forms-input__radio-button:not(:checked)');
+			if (unchecked) {
+				unchecked.checked = true;
+			}
+		}
+		this.savedEvent({ success: false });
+	}
+	redirect () {
+		window.location.assign(`/login${document.referrer ? `?location=${document.referrer}` : ''}`);
+	}
+	savedEvent ({ success }) {
+		const event = new CustomEvent('consent-form:saved', {
+			detail: {
+				success
+			}
+		});
+		this.element.dispatchEvent(event);
+	}
+	onChange (callback) {
+		this.radios.forEach((radio) => {
+			radio.addEventListener('change', (e) => {
+				const consent = this.consentFromRadio(radio);
+				const radioWrapper = radio.closest('.o-forms-input');
+				if (radioWrapper) {
+					radioWrapper.classList.add('o-forms-input--saving');
+					radioWrapper.classList.remove('o-forms-input--saved');
+					callback(consent, e)
+						.then(result => {
+							if (result === 'success') {
+								return this.saveSuccess(radioWrapper);
+							}
+							if (result === 'redirect') {
+								return this.redirect();
+							}
+							this.saveFail(radioWrapper);
+						})
+						.catch(() => {
+							this.saveFail(radioWrapper);
+						});
+				}
+			});
+		});
+	}
 }
 exports.LiveUpdateConsent = LiveUpdateConsent;

--- a/dist/commonjs/client/live-update.js
+++ b/dist/commonjs/client/live-update.js
@@ -10,7 +10,7 @@ class LiveUpdateConsent extends consent_1.ConsentForm {
 	}
 	saveSuccess (radioWrapper) {
 		if (radioWrapper) {
-			radioWrapper.classList.remove('o-forms-input--error');
+			radioWrapper.classList.remove('o-forms-input--invalid');
 			radioWrapper.classList.remove('o-forms-input--saving');
 			radioWrapper.classList.add('o-forms-input--saved');
 		}
@@ -19,8 +19,8 @@ class LiveUpdateConsent extends consent_1.ConsentForm {
 	saveFail (radioWrapper) {
 		if (radioWrapper) {
 			radioWrapper.classList.remove('o-forms-input--saving');
-			radioWrapper.classList.add('o-forms-input--error');
-			const unchecked = radioWrapper.querySelector('.o-forms-input__radio-button:not(:checked)');
+			radioWrapper.classList.add('o-forms-input--invalid');
+			const unchecked = radioWrapper.querySelector('.consent-form__radio-button:not(:checked)');
 			if (unchecked) {
 				unchecked.checked = true;
 			}

--- a/dist/commonjs/client/main.js
+++ b/dist/commonjs/client/main.js
@@ -1,12 +1,12 @@
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const reconsent_1 = require("./reconsent");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const reconsent_1 = require('./reconsent');
 exports.Reconsent = reconsent_1.Reconsent;
-const live_update_1 = require("./live-update");
+const live_update_1 = require('./live-update');
 exports.LiveUpdateConsent = live_update_1.LiveUpdateConsent;
-const update_on_save_1 = require("./update-on-save");
+const update_on_save_1 = require('./update-on-save');
 exports.UpdateConsentOnSave = update_on_save_1.UpdateConsentOnSave;
-const message_1 = require("./message");
+const message_1 = require('./message');
 exports.ConsentMessage = message_1.ConsentMessage;
-const helpers = require("../helpers");
+const helpers = require('../helpers');
 exports.helpers = helpers;

--- a/dist/commonjs/client/message.js
+++ b/dist/commonjs/client/message.js
@@ -1,34 +1,34 @@
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const o_message_1 = require("o-message");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const o_message_1 = require('o-message');
 class ConsentMessage {
-    constructor(options) {
-        this.options = options;
-        const element = document.querySelector(`${this.options.selector} > .o-message`);
-        if (!element) {
-            throw new Error('Invalid selector');
-        }
-        this.element = element;
-        this._message = new o_message_1.default(this.element, {
-            messageClass: 'o-message'
-        });
-        if (this.options.hideOnInit) {
-            this.hide();
-        }
-    }
-    hide() {
-        this.element.classList.add('consent-message--hidden');
-    }
-    show() {
-        this.element.classList.remove('consent-message--hidden');
-    }
-    init(showMessage) {
-        if (showMessage) {
-            this.show();
-        }
-        else {
-            this.hide();
-        }
-    }
+	constructor (options) {
+		this.options = options;
+		const element = document.querySelector(`${this.options.selector} > .o-message`);
+		if (!element) {
+			throw new Error('Invalid selector');
+		}
+		this.element = element;
+		this._message = new o_message_1.default(this.element, {
+			messageClass: 'o-message'
+		});
+		if (this.options.hideOnInit) {
+			this.hide();
+		}
+	}
+	hide () {
+		this.element.classList.add('consent-message--hidden');
+	}
+	show () {
+		this.element.classList.remove('consent-message--hidden');
+	}
+	init (showMessage) {
+		if (showMessage) {
+			this.show();
+		}
+		else {
+			this.hide();
+		}
+	}
 }
 exports.ConsentMessage = ConsentMessage;

--- a/dist/commonjs/client/reconsent.js
+++ b/dist/commonjs/client/reconsent.js
@@ -1,33 +1,33 @@
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const update_on_save_1 = require("./update-on-save");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const update_on_save_1 = require('./update-on-save');
 class Reconsent extends update_on_save_1.UpdateConsentOnSave {
-    constructor(opts) {
-        super(opts);
-        if (opts.flag === 'autoload') {
-            this.overlaySetup();
-        }
-        else if (opts.flag === 'banner') {
-            this.bannerSetup();
-        }
-    }
-    bannerSetup() {
-        const banner = document.querySelector('.consent-banner__outer');
-        const bannerButton = document.querySelector('.consent-banner__button');
-        banner.classList.add('active');
-        bannerButton.addEventListener('click', () => {
-            banner.classList.remove('active');
-            this.overlaySetup();
-        });
-    }
-    overlaySetup() {
-    }
-    overlayCloseHandler() {
-        const closeConsentForm = document.querySelector('.consent-form__close');
-        closeConsentForm.addEventListener('click', () => {
-            this.consentOverlay.close();
-        });
-    }
+	constructor (opts) {
+		super(opts);
+		if (opts.flag === 'autoload') {
+			this.overlaySetup();
+		}
+		else if (opts.flag === 'banner') {
+			this.bannerSetup();
+		}
+	}
+	bannerSetup () {
+		const banner = document.querySelector('.consent-banner__outer');
+		const bannerButton = document.querySelector('.consent-banner__button');
+		banner.classList.add('active');
+		bannerButton.addEventListener('click', () => {
+			banner.classList.remove('active');
+			this.overlaySetup();
+		});
+	}
+	overlaySetup () {
+	}
+	overlayCloseHandler () {
+		const closeConsentForm = document.querySelector('.consent-form__close');
+		closeConsentForm.addEventListener('click', () => {
+			this.consentOverlay.close();
+		});
+	}
 }
 exports.Reconsent = Reconsent;
 ;

--- a/dist/commonjs/client/update-on-save.js
+++ b/dist/commonjs/client/update-on-save.js
@@ -1,53 +1,53 @@
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const consent_1 = require("./consent");
-const helpers_1 = require("../helpers");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const consent_1 = require('./consent');
+const helpers_1 = require('../helpers');
 class UpdateConsentOnSave extends consent_1.ConsentForm {
-    constructor(opts) {
-        super(opts);
-        if (this.submitButton && this.options.checkValidityBeforeSubmit && !this.checkValidity()) {
-            this.submitButton.disabled = true;
-        }
-    }
-    get values() {
-        const radios = this.getRadios(true);
-        const consentObject = {};
-        radios.forEach((radio) => {
-            consentObject[radio.name] = radio.value;
-        });
-        return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
-    }
-    checkValidity() {
-        for (const radio of this.radios) {
-            if (!radio.checkValidity()) {
-                return false;
-            }
-        }
-        return true;
-    }
-    onChange(callback) {
-        if (callback || this.options.checkValidityBeforeSubmit) {
-            this.radios.forEach((radio) => {
-                radio.addEventListener('change', e => {
-                    if (this.submitButton && this.options.checkValidityBeforeSubmit && this.checkValidity()) {
-                        this.submitButton.disabled = false;
-                    }
-                    if (callback) {
-                        const consent = this.consentFromRadio(radio);
-                        callback(consent, e);
-                    }
-                });
-            });
-        }
-    }
-    onSubmit(callback) {
-        if (this.submitButton) {
-            this.submitButton.addEventListener('click', e => {
-                e.preventDefault();
-                e.stopPropagation();
-                callback(this.values, e);
-            });
-        }
-    }
+	constructor (opts) {
+		super(opts);
+		if (this.submitButton && this.options.checkValidityBeforeSubmit && !this.checkValidity()) {
+			this.submitButton.disabled = true;
+		}
+	}
+	get values () {
+		const radios = this.getRadios(true);
+		let consentObject = {};
+		radios.forEach((radio) => {
+			consentObject[radio.name] = radio.value;
+		});
+		return helpers_1.buildConsentRecord(this.fow, consentObject, this.source);
+	}
+	checkValidity () {
+		for (const radio of this.radios) {
+			if (!radio.checkValidity()) {
+				return false;
+			}
+		}
+		return true;
+	}
+	onChange (callback) {
+		if (callback || this.options.checkValidityBeforeSubmit) {
+			this.radios.forEach((radio) => {
+				radio.addEventListener('change', e => {
+					if (this.submitButton && this.options.checkValidityBeforeSubmit && this.checkValidity()) {
+						this.submitButton.disabled = false;
+					}
+					if (callback) {
+						const consent = this.consentFromRadio(radio);
+						callback(consent, e);
+					}
+				});
+			});
+		}
+	}
+	onSubmit (callback) {
+		if (this.submitButton) {
+			this.submitButton.addEventListener('click', e => {
+				e.preventDefault();
+				e.stopPropagation();
+				callback(this.values, e);
+			});
+		}
+	}
 }
 exports.UpdateConsentOnSave = UpdateConsentOnSave;

--- a/dist/commonjs/helpers.js
+++ b/dist/commonjs/helpers.js
@@ -1,103 +1,103 @@
-
-Object.defineProperty(exports, "__esModule", { value: true });
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
 const Rx = /\b(lbi|consent)-(\w+)-(\w+)\b/;
-function isConsentField(name) {
-    return Rx.test(name);
+function isConsentField (name) {
+	return Rx.test(name);
 }
 exports.isConsentField = isConsentField;
-function extractMetaFromString(name) {
-    const match = Rx.exec(name);
-    if (!match) {
-        return null;
-    }
-    const [, fieldType, category, channel] = match;
-    const lbi = fieldType === 'lbi';
-    return {
-        lbi,
-        channel,
-        category
-    };
+function extractMetaFromString (name) {
+	const match = Rx.exec(name);
+	if (!match) {
+		return null;
+	}
+	const [, fieldType, category, channel] = match;
+	const lbi = fieldType === 'lbi';
+	return {
+		lbi,
+		channel,
+		category
+	};
 }
 exports.extractMetaFromString = extractMetaFromString;
-function decorateChannel(options) {
-    const { fowChannel, consentChannel, elementAttrs } = options;
-    let checkedYes = false;
-    let checkedNo = false;
-    if (consentChannel) {
-        checkedYes = consentChannel.status;
-        checkedNo = !checkedYes;
-    }
-    else if (fowChannel.lbi) {
-        checkedYes = true;
-    }
-    return Object.assign(fowChannel, {
-        checkedYes,
-        checkedNo,
-        elementAttrs
-    });
+function decorateChannel (options) {
+	let { fowChannel, consentChannel, elementAttrs } = options;
+	let checkedYes = false;
+	let checkedNo = false;
+	if (consentChannel) {
+		checkedYes = consentChannel.status;
+		checkedNo = !checkedYes;
+	}
+	else if (fowChannel.lbi) {
+		checkedYes = true;
+	}
+	return Object.assign(fowChannel, {
+		checkedYes,
+		checkedNo,
+		elementAttrs
+	});
 }
 exports.decorateChannel = decorateChannel;
-function populateConsentModel(options) {
-    const { fow, source, consent, elementAttrs } = options;
-    const getConsent = (category, channel) => !consent || consent.hasOwnProperty('fow')
-        ? consent
-        : (consent[category] || {})[channel];
-    fow.source = source;
-    fow.consents = fow.consents.map((categoryObj) => {
-        categoryObj.channels.map((channelObj) => decorateChannel({
-            fowChannel: channelObj,
-            consentChannel: getConsent(categoryObj.category, channelObj.channel),
-            elementAttrs
-        }));
-        return categoryObj;
-    });
-    return fow;
+function populateConsentModel (options) {
+	let { fow, source, consent, elementAttrs } = options;
+	const getConsent = (category, channel) => !consent || consent.hasOwnProperty('fow')
+		? consent
+		: (consent[category] || {})[channel];
+	fow.source = source;
+	fow.consents = fow.consents.map((categoryObj) => {
+		categoryObj.channels.map((channelObj) => decorateChannel({
+			fowChannel: channelObj,
+			consentChannel: getConsent(categoryObj.category, channelObj.channel),
+			elementAttrs
+		}));
+		return categoryObj;
+	});
+	return fow;
 }
 exports.populateConsentModel = populateConsentModel;
-function validateConsent(fow, category, channel) {
-    if (typeof fow === 'string') {
-        return true;
-    }
-    const categoryObj = fow.consents.find(categoryObj => categoryObj.category === category);
-    if (!categoryObj) {
-        throw new Error(`Category ${category} does not match form of words`);
-    }
-    const validChannel = categoryObj.channels.some(channelObj => channelObj.channel === channel);
-    if (!validChannel) {
-        throw new Error(`Channel ${channel} does not match form of words`);
-    }
-    return true;
+function validateConsent (fow, category, channel) {
+	if (typeof fow === 'string') {
+		return true;
+	}
+	const categoryObj = fow.consents.find(categoryObj => categoryObj.category === category);
+	if (!categoryObj) {
+		throw new Error(`Category ${category} does not match form of words`);
+	}
+	const validChannel = categoryObj.channels.some(channelObj => channelObj.channel === channel);
+	if (!validChannel) {
+		throw new Error(`Channel ${channel} does not match form of words`);
+	}
+	return true;
 }
 exports.validateConsent = validateConsent;
-function buildConsentRecord(fow, keyedConsents, source) {
-    let consentRecord;
-    const { id: fowId } = typeof fow === 'string' || !fow ? { id: fow } : fow;
-    if (!fow || !fowId) {
-        throw new Error('Missing form of words (fow) id');
-    }
-    if (!source) {
-        throw new Error('Missing consent source');
-    }
-    for (const key of Object.keys(keyedConsents)) {
-        const value = keyedConsents[key];
-        const consent = extractMetaFromString(key);
-        if (consent) {
-            const { category, channel, lbi } = consent;
-            if (validateConsent(fow, category, channel)) {
-                consentRecord = consentRecord || {};
-                consentRecord[category] = consentRecord[category] || {};
-                consentRecord[category][channel] = {
-                    status: value === 'yes',
-                    lbi,
-                    source,
-                    fow: fowId
-                };
-            }
-        }
-    }
-    if (!consentRecord) {
-        throw new Error('Found no valid consents');
-    }
-    return consentRecord;
+function buildConsentRecord (fow, keyedConsents, source) {
+	let consentRecord;
+	const { id: fowId } = typeof fow === 'string' || !fow ? { id: fow } : fow;
+	if (!fow || !fowId) {
+		throw new Error('Missing form of words (fow) id');
+	}
+	if (!source) {
+		throw new Error('Missing consent source');
+	}
+	for (let key of Object.keys(keyedConsents)) {
+		const value = keyedConsents[key];
+		const consent = extractMetaFromString(key);
+		if (consent) {
+			const { category, channel, lbi } = consent;
+			if (validateConsent(fow, category, channel)) {
+				consentRecord = consentRecord || {};
+				consentRecord[category] = consentRecord[category] || {};
+				consentRecord[category][channel] = {
+					status: value === 'yes',
+					lbi,
+					source,
+					fow: fowId
+				};
+			}
+		}
+	}
+	if (!consentRecord) {
+		throw new Error('Found no valid consents');
+	}
+	return consentRecord;
 }
 exports.buildConsentRecord = buildConsentRecord;

--- a/dist/commonjs/server/main.js
+++ b/dist/commonjs/server/main.js
@@ -1,16 +1,16 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-require("isomorphic-fetch");
-const helpers = require("../helpers");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+require('isomorphic-fetch');
+const helpers = require('../helpers');
 exports.helpers = helpers;
-async function getFormOfWords(name, scope = 'FTPINK') {
-    if (!process.env.FOW_API_HOST) {
-        throw new Error('Missing FOW_API_HOST environment variable');
-    }
-    const url = `${process.env.FOW_API_HOST}/api/v1/${scope}/${name}`;
-    const fow = await fetch(url, {
-        timeout: 2000
-    });
-    return await fow.json();
+async function getFormOfWords (name, scope = 'FTPINK') {
+	if (!process.env.FOW_API_HOST) {
+		throw new Error('Missing FOW_API_HOST environment variable');
+	}
+	const url = `${process.env.FOW_API_HOST}/api/v1/${scope}/${name}`;
+	const fow = await fetch(url, {
+		timeout: 2000
+	});
+	return await fow.json();
 }
 exports.getFormOfWords = getFormOfWords;

--- a/dist/esm/client/consent.js
+++ b/dist/esm/client/consent.js
@@ -1,35 +1,35 @@
 import { buildConsentRecord } from '../helpers';
 export class ConsentForm {
-    constructor(opts) {
-        const element = document.querySelector(opts.selector);
-        if (!element) {
-            throw new Error('Invalid selector');
-        }
-        this.element = element;
-        const fow = this.getValue('formOfWordsId');
-        if (!fow) {
-            throw new Error('Form of words field missing');
-        }
-        this.fow = fow;
-        const source = this.getValue('consentSource');
-        if (!source) {
-            throw new Error('Consent source field missing');
-        }
-        this.source = source;
-        this.scope = this.getValue('formOfWordsScope') || 'FTPINK';
-        this.radios = this.getRadios();
-        this.submitButton = this.element.querySelector('.consent-form__submit');
-        this.options = opts;
-    }
-    getValue(name) {
-        const field = this.element.querySelector(`input[name='${name}']`);
-        return field ? field.value : null;
-    }
-    getRadios(checked) {
-        return Array.from(this.element.querySelectorAll(`.consent-form__radio-button${checked ? ':checked' : ''}`));
-    }
-    consentFromRadio(radio) {
-        const consentObject = { [radio.name]: radio.value };
-        return buildConsentRecord(this.fow, consentObject, this.source);
-    }
+	constructor (opts) {
+		const element = document.querySelector(opts.selector);
+		if (!element) {
+			throw new Error('Invalid selector');
+		}
+		this.element = element;
+		const fow = this.getValue('formOfWordsId');
+		if (!fow) {
+			throw new Error('Form of words field missing');
+		}
+		this.fow = fow;
+		const source = this.getValue('consentSource');
+		if (!source) {
+			throw new Error('Consent source field missing');
+		}
+		this.source = source;
+		this.scope = this.getValue('formOfWordsScope') || 'FTPINK';
+		this.radios = this.getRadios();
+		this.submitButton = this.element.querySelector('.consent-form__submit');
+		this.options = opts;
+	}
+	getValue (name) {
+		const field = this.element.querySelector(`input[name='${name}']`);
+		return field ? field.value : null;
+	}
+	getRadios (checked) {
+		return Array.from(this.element.querySelectorAll(`.consent-form__radio-button${checked ? ':checked' : ''}`));
+	}
+	consentFromRadio (radio) {
+		const consentObject = { [radio.name]: radio.value };
+		return buildConsentRecord(this.fow, consentObject, this.source);
+	}
 }

--- a/dist/esm/client/live-update.js
+++ b/dist/esm/client/live-update.js
@@ -8,7 +8,7 @@ export class LiveUpdateConsent extends ConsentForm {
 	}
 	saveSuccess (radioWrapper) {
 		if (radioWrapper) {
-			radioWrapper.classList.remove('o-forms-input--error');
+			radioWrapper.classList.remove('o-forms-input--invalid');
 			radioWrapper.classList.remove('o-forms-input--saving');
 			radioWrapper.classList.add('o-forms-input--saved');
 		}
@@ -17,8 +17,8 @@ export class LiveUpdateConsent extends ConsentForm {
 	saveFail (radioWrapper) {
 		if (radioWrapper) {
 			radioWrapper.classList.remove('o-forms-input--saving');
-			radioWrapper.classList.add('o-forms-input--error');
-			const unchecked = radioWrapper.querySelector('.o-forms-input__radio-button:not(:checked)');
+			radioWrapper.classList.add('o-forms-input--invalid');
+			const unchecked = radioWrapper.querySelector('.consent-form__radio-button:not(:checked)');
 			if (unchecked) {
 				unchecked.checked = true;
 			}

--- a/dist/esm/client/live-update.js
+++ b/dist/esm/client/live-update.js
@@ -1,64 +1,64 @@
 import { ConsentForm } from './consent';
 export class LiveUpdateConsent extends ConsentForm {
-    constructor(opts) {
-        super(opts);
-        if (this.submitButton) {
-            this.submitButton.style.display = 'none';
-        }
-    }
-    saveSuccess(radioWrapper) {
-        if (radioWrapper) {
-            radioWrapper.classList.remove('o-forms-input--error');
-            radioWrapper.classList.remove('o-forms-input--saving');
-            radioWrapper.classList.add('o-forms-input--saved');
-        }
-        this.savedEvent({ success: true });
-    }
-    saveFail(radioWrapper) {
-        if (radioWrapper) {
-            radioWrapper.classList.remove('o-forms-input--saving');
-            radioWrapper.classList.add('o-forms-input--error');
-            const unchecked = radioWrapper.querySelector('.o-forms-input__radio-button:not(:checked)');
-            if (unchecked) {
-                unchecked.checked = true;
-            }
-        }
-        this.savedEvent({ success: false });
-    }
-    redirect() {
-        window.location.assign(`/login${document.referrer ? `?location=${document.referrer}` : ''}`);
-    }
-    savedEvent({ success }) {
-        const event = new CustomEvent('consent-form:saved', {
-            detail: {
-                success
-            }
-        });
-        this.element.dispatchEvent(event);
-    }
-    onChange(callback) {
-        this.radios.forEach((radio) => {
-            radio.addEventListener('change', (e) => {
-                const consent = this.consentFromRadio(radio);
-                const radioWrapper = radio.closest('.o-forms-input');
-                if (radioWrapper) {
-                    radioWrapper.classList.add('o-forms-input--saving');
-                    radioWrapper.classList.remove('o-forms-input--saved');
-                    callback(consent, e)
-                        .then(result => {
-                        if (result === 'success') {
-                            return this.saveSuccess(radioWrapper);
-                        }
-                        if (result === 'redirect') {
-                            return this.redirect();
-                        }
-                        this.saveFail(radioWrapper);
-                    })
-                        .catch(() => {
-                        this.saveFail(radioWrapper);
-                    });
-                }
-            });
-        });
-    }
+	constructor (opts) {
+		super(opts);
+		if (this.submitButton) {
+			this.submitButton.style.display = 'none';
+		}
+	}
+	saveSuccess (radioWrapper) {
+		if (radioWrapper) {
+			radioWrapper.classList.remove('o-forms-input--error');
+			radioWrapper.classList.remove('o-forms-input--saving');
+			radioWrapper.classList.add('o-forms-input--saved');
+		}
+		this.savedEvent({ success: true });
+	}
+	saveFail (radioWrapper) {
+		if (radioWrapper) {
+			radioWrapper.classList.remove('o-forms-input--saving');
+			radioWrapper.classList.add('o-forms-input--error');
+			const unchecked = radioWrapper.querySelector('.o-forms-input__radio-button:not(:checked)');
+			if (unchecked) {
+				unchecked.checked = true;
+			}
+		}
+		this.savedEvent({ success: false });
+	}
+	redirect () {
+		window.location.assign(`/login${document.referrer ? `?location=${document.referrer}` : ''}`);
+	}
+	savedEvent ({ success }) {
+		const event = new CustomEvent('consent-form:saved', {
+			detail: {
+				success
+			}
+		});
+		this.element.dispatchEvent(event);
+	}
+	onChange (callback) {
+		this.radios.forEach((radio) => {
+			radio.addEventListener('change', (e) => {
+				const consent = this.consentFromRadio(radio);
+				const radioWrapper = radio.closest('.o-forms-input');
+				if (radioWrapper) {
+					radioWrapper.classList.add('o-forms-input--saving');
+					radioWrapper.classList.remove('o-forms-input--saved');
+					callback(consent, e)
+						.then(result => {
+							if (result === 'success') {
+								return this.saveSuccess(radioWrapper);
+							}
+							if (result === 'redirect') {
+								return this.redirect();
+							}
+							this.saveFail(radioWrapper);
+						})
+						.catch(() => {
+							this.saveFail(radioWrapper);
+						});
+				}
+			});
+		});
+	}
 }

--- a/dist/esm/client/message.js
+++ b/dist/esm/client/message.js
@@ -1,31 +1,31 @@
 import oMessage from 'o-message';
 export class ConsentMessage {
-    constructor(options) {
-        this.options = options;
-        const element = document.querySelector(`${this.options.selector} > .o-message`);
-        if (!element) {
-            throw new Error('Invalid selector');
-        }
-        this.element = element;
-        this._message = new oMessage(this.element, {
-            messageClass: 'o-message'
-        });
-        if (this.options.hideOnInit) {
-            this.hide();
-        }
-    }
-    hide() {
-        this.element.classList.add('consent-message--hidden');
-    }
-    show() {
-        this.element.classList.remove('consent-message--hidden');
-    }
-    init(showMessage) {
-        if (showMessage) {
-            this.show();
-        }
-        else {
-            this.hide();
-        }
-    }
+	constructor (options) {
+		this.options = options;
+		const element = document.querySelector(`${this.options.selector} > .o-message`);
+		if (!element) {
+			throw new Error('Invalid selector');
+		}
+		this.element = element;
+		this._message = new oMessage(this.element, {
+			messageClass: 'o-message'
+		});
+		if (this.options.hideOnInit) {
+			this.hide();
+		}
+	}
+	hide () {
+		this.element.classList.add('consent-message--hidden');
+	}
+	show () {
+		this.element.classList.remove('consent-message--hidden');
+	}
+	init (showMessage) {
+		if (showMessage) {
+			this.show();
+		}
+		else {
+			this.hide();
+		}
+	}
 }

--- a/dist/esm/client/reconsent.js
+++ b/dist/esm/client/reconsent.js
@@ -1,30 +1,30 @@
 import { UpdateConsentOnSave } from './update-on-save';
 export class Reconsent extends UpdateConsentOnSave {
-    constructor(opts) {
-        super(opts);
-        if (opts.flag === 'autoload') {
-            this.overlaySetup();
-        }
-        else if (opts.flag === 'banner') {
-            this.bannerSetup();
-        }
-    }
-    bannerSetup() {
-        const banner = document.querySelector('.consent-banner__outer');
-        const bannerButton = document.querySelector('.consent-banner__button');
-        banner.classList.add('active');
-        bannerButton.addEventListener('click', () => {
-            banner.classList.remove('active');
-            this.overlaySetup();
-        });
-    }
-    overlaySetup() {
-    }
-    overlayCloseHandler() {
-        const closeConsentForm = document.querySelector('.consent-form__close');
-        closeConsentForm.addEventListener('click', () => {
-            this.consentOverlay.close();
-        });
-    }
+	constructor (opts) {
+		super(opts);
+		if (opts.flag === 'autoload') {
+			this.overlaySetup();
+		}
+		else if (opts.flag === 'banner') {
+			this.bannerSetup();
+		}
+	}
+	bannerSetup () {
+		const banner = document.querySelector('.consent-banner__outer');
+		const bannerButton = document.querySelector('.consent-banner__button');
+		banner.classList.add('active');
+		bannerButton.addEventListener('click', () => {
+			banner.classList.remove('active');
+			this.overlaySetup();
+		});
+	}
+	overlaySetup () {
+	}
+	overlayCloseHandler () {
+		const closeConsentForm = document.querySelector('.consent-form__close');
+		closeConsentForm.addEventListener('click', () => {
+			this.consentOverlay.close();
+		});
+	}
 }
 ;

--- a/dist/esm/client/update-on-save.js
+++ b/dist/esm/client/update-on-save.js
@@ -1,50 +1,50 @@
 import { ConsentForm } from './consent';
 import { buildConsentRecord } from '../helpers';
 export class UpdateConsentOnSave extends ConsentForm {
-    constructor(opts) {
-        super(opts);
-        if (this.submitButton && this.options.checkValidityBeforeSubmit && !this.checkValidity()) {
-            this.submitButton.disabled = true;
-        }
-    }
-    get values() {
-        const radios = this.getRadios(true);
-        const consentObject = {};
-        radios.forEach((radio) => {
-            consentObject[radio.name] = radio.value;
-        });
-        return buildConsentRecord(this.fow, consentObject, this.source);
-    }
-    checkValidity() {
-        for (const radio of this.radios) {
-            if (!radio.checkValidity()) {
-                return false;
-            }
-        }
-        return true;
-    }
-    onChange(callback) {
-        if (callback || this.options.checkValidityBeforeSubmit) {
-            this.radios.forEach((radio) => {
-                radio.addEventListener('change', e => {
-                    if (this.submitButton && this.options.checkValidityBeforeSubmit && this.checkValidity()) {
-                        this.submitButton.disabled = false;
-                    }
-                    if (callback) {
-                        const consent = this.consentFromRadio(radio);
-                        callback(consent, e);
-                    }
-                });
-            });
-        }
-    }
-    onSubmit(callback) {
-        if (this.submitButton) {
-            this.submitButton.addEventListener('click', e => {
-                e.preventDefault();
-                e.stopPropagation();
-                callback(this.values, e);
-            });
-        }
-    }
+	constructor (opts) {
+		super(opts);
+		if (this.submitButton && this.options.checkValidityBeforeSubmit && !this.checkValidity()) {
+			this.submitButton.disabled = true;
+		}
+	}
+	get values () {
+		const radios = this.getRadios(true);
+		let consentObject = {};
+		radios.forEach((radio) => {
+			consentObject[radio.name] = radio.value;
+		});
+		return buildConsentRecord(this.fow, consentObject, this.source);
+	}
+	checkValidity () {
+		for (const radio of this.radios) {
+			if (!radio.checkValidity()) {
+				return false;
+			}
+		}
+		return true;
+	}
+	onChange (callback) {
+		if (callback || this.options.checkValidityBeforeSubmit) {
+			this.radios.forEach((radio) => {
+				radio.addEventListener('change', e => {
+					if (this.submitButton && this.options.checkValidityBeforeSubmit && this.checkValidity()) {
+						this.submitButton.disabled = false;
+					}
+					if (callback) {
+						const consent = this.consentFromRadio(radio);
+						callback(consent, e);
+					}
+				});
+			});
+		}
+	}
+	onSubmit (callback) {
+		if (this.submitButton) {
+			this.submitButton.addEventListener('click', e => {
+				e.preventDefault();
+				e.stopPropagation();
+				callback(this.values, e);
+			});
+		}
+	}
 }

--- a/dist/esm/helpers.js
+++ b/dist/esm/helpers.js
@@ -1,95 +1,95 @@
 const Rx = /\b(lbi|consent)-(\w+)-(\w+)\b/;
-export function isConsentField(name) {
-    return Rx.test(name);
+export function isConsentField (name) {
+	return Rx.test(name);
 }
-export function extractMetaFromString(name) {
-    const match = Rx.exec(name);
-    if (!match) {
-        return null;
-    }
-    const [, fieldType, category, channel] = match;
-    const lbi = fieldType === 'lbi';
-    return {
-        lbi,
-        channel,
-        category
-    };
+export function extractMetaFromString (name) {
+	const match = Rx.exec(name);
+	if (!match) {
+		return null;
+	}
+	const [, fieldType, category, channel] = match;
+	const lbi = fieldType === 'lbi';
+	return {
+		lbi,
+		channel,
+		category
+	};
 }
-export function decorateChannel(options) {
-    const { fowChannel, consentChannel, elementAttrs } = options;
-    let checkedYes = false;
-    let checkedNo = false;
-    if (consentChannel) {
-        checkedYes = consentChannel.status;
-        checkedNo = !checkedYes;
-    }
-    else if (fowChannel.lbi) {
-        checkedYes = true;
-    }
-    return Object.assign(fowChannel, {
-        checkedYes,
-        checkedNo,
-        elementAttrs
-    });
+export function decorateChannel (options) {
+	let { fowChannel, consentChannel, elementAttrs } = options;
+	let checkedYes = false;
+	let checkedNo = false;
+	if (consentChannel) {
+		checkedYes = consentChannel.status;
+		checkedNo = !checkedYes;
+	}
+	else if (fowChannel.lbi) {
+		checkedYes = true;
+	}
+	return Object.assign(fowChannel, {
+		checkedYes,
+		checkedNo,
+		elementAttrs
+	});
 }
-export function populateConsentModel(options) {
-    const { fow, source, consent, elementAttrs } = options;
-    const getConsent = (category, channel) => !consent || consent.hasOwnProperty('fow')
-        ? consent
-        : (consent[category] || {})[channel];
-    fow.source = source;
-    fow.consents = fow.consents.map((categoryObj) => {
-        categoryObj.channels.map((channelObj) => decorateChannel({
-            fowChannel: channelObj,
-            consentChannel: getConsent(categoryObj.category, channelObj.channel),
-            elementAttrs
-        }));
-        return categoryObj;
-    });
-    return fow;
+export function populateConsentModel (options) {
+	let { fow, source, consent, elementAttrs } = options;
+	const getConsent = (category, channel) => !consent || consent.hasOwnProperty('fow')
+		? consent
+		: (consent[category] || {})[channel];
+	fow.source = source;
+	fow.consents = fow.consents.map((categoryObj) => {
+		categoryObj.channels.map((channelObj) => decorateChannel({
+			fowChannel: channelObj,
+			consentChannel: getConsent(categoryObj.category, channelObj.channel),
+			elementAttrs
+		}));
+		return categoryObj;
+	});
+	return fow;
 }
-export function validateConsent(fow, category, channel) {
-    if (typeof fow === 'string') {
-        return true;
-    }
-    const categoryObj = fow.consents.find(categoryObj => categoryObj.category === category);
-    if (!categoryObj) {
-        throw new Error(`Category ${category} does not match form of words`);
-    }
-    const validChannel = categoryObj.channels.some(channelObj => channelObj.channel === channel);
-    if (!validChannel) {
-        throw new Error(`Channel ${channel} does not match form of words`);
-    }
-    return true;
+export function validateConsent (fow, category, channel) {
+	if (typeof fow === 'string') {
+		return true;
+	}
+	const categoryObj = fow.consents.find(categoryObj => categoryObj.category === category);
+	if (!categoryObj) {
+		throw new Error(`Category ${category} does not match form of words`);
+	}
+	const validChannel = categoryObj.channels.some(channelObj => channelObj.channel === channel);
+	if (!validChannel) {
+		throw new Error(`Channel ${channel} does not match form of words`);
+	}
+	return true;
 }
-export function buildConsentRecord(fow, keyedConsents, source) {
-    let consentRecord;
-    const { id: fowId } = typeof fow === 'string' || !fow ? { id: fow } : fow;
-    if (!fow || !fowId) {
-        throw new Error('Missing form of words (fow) id');
-    }
-    if (!source) {
-        throw new Error('Missing consent source');
-    }
-    for (const key of Object.keys(keyedConsents)) {
-        const value = keyedConsents[key];
-        const consent = extractMetaFromString(key);
-        if (consent) {
-            const { category, channel, lbi } = consent;
-            if (validateConsent(fow, category, channel)) {
-                consentRecord = consentRecord || {};
-                consentRecord[category] = consentRecord[category] || {};
-                consentRecord[category][channel] = {
-                    status: value === 'yes',
-                    lbi,
-                    source,
-                    fow: fowId
-                };
-            }
-        }
-    }
-    if (!consentRecord) {
-        throw new Error('Found no valid consents');
-    }
-    return consentRecord;
+export function buildConsentRecord (fow, keyedConsents, source) {
+	let consentRecord;
+	const { id: fowId } = typeof fow === 'string' || !fow ? { id: fow } : fow;
+	if (!fow || !fowId) {
+		throw new Error('Missing form of words (fow) id');
+	}
+	if (!source) {
+		throw new Error('Missing consent source');
+	}
+	for (let key of Object.keys(keyedConsents)) {
+		const value = keyedConsents[key];
+		const consent = extractMetaFromString(key);
+		if (consent) {
+			const { category, channel, lbi } = consent;
+			if (validateConsent(fow, category, channel)) {
+				consentRecord = consentRecord || {};
+				consentRecord[category] = consentRecord[category] || {};
+				consentRecord[category][channel] = {
+					status: value === 'yes',
+					lbi,
+					source,
+					fow: fowId
+				};
+			}
+		}
+	}
+	if (!consentRecord) {
+		throw new Error('Found no valid consents');
+	}
+	return consentRecord;
 }

--- a/dist/esm/server/main.js
+++ b/dist/esm/server/main.js
@@ -1,13 +1,13 @@
 import 'isomorphic-fetch';
 import * as helpers from '../helpers';
-export async function getFormOfWords(name, scope = 'FTPINK') {
-    if (!process.env.FOW_API_HOST) {
-        throw new Error('Missing FOW_API_HOST environment variable');
-    }
-    const url = `${process.env.FOW_API_HOST}/api/v1/${scope}/${name}`;
-    const fow = await fetch(url, {
-        timeout: 2000
-    });
-    return await fow.json();
+export async function getFormOfWords (name, scope = 'FTPINK') {
+	if (!process.env.FOW_API_HOST) {
+		throw new Error('Missing FOW_API_HOST environment variable');
+	}
+	const url = `${process.env.FOW_API_HOST}/api/v1/${scope}/${name}`;
+	const fow = await fetch(url, {
+		timeout: 2000
+	});
+	return await fow.json();
 }
 export { helpers };

--- a/src/js/client/live-update.ts
+++ b/src/js/client/live-update.ts
@@ -11,7 +11,7 @@ export class LiveUpdateConsent extends ConsentForm {
 
 	private saveSuccess (radioWrapper) {
 		if (radioWrapper) {
-			radioWrapper.classList.remove('o-forms-input--error');
+			radioWrapper.classList.remove('o-forms-input--invalid');
 			radioWrapper.classList.remove('o-forms-input--saving');
 			radioWrapper.classList.add('o-forms-input--saved');
 		}
@@ -21,9 +21,9 @@ export class LiveUpdateConsent extends ConsentForm {
 	private saveFail (radioWrapper) {
 		if (radioWrapper) {
 			radioWrapper.classList.remove('o-forms-input--saving');
-			radioWrapper.classList.add('o-forms-input--error');
+			radioWrapper.classList.add('o-forms-input--invalid');
 			// reset radio to previous value
-			const unchecked = radioWrapper.querySelector('.o-forms-input__radio-button:not(:checked)');
+			const unchecked = radioWrapper.querySelector('.consent-form__radio-button:not(:checked)');
 			if (unchecked) {
 				unchecked.checked = true;
 			}

--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -94,3 +94,21 @@ $two-thirds-width: percentage(2 / 3);
 		margin-bottom: 0;
 	}
 }
+
+.consent-form__item-advisory {
+	@include oTypographySans(0);
+	background-color: oColorsByName('wheat');
+	padding: oSpacingByName('s3') oSpacingByName('s4') oSpacingByName('s4');
+	margin-top: oSpacingByName('s6');
+	@include oGridRespondTo($until: S) {
+		margin-bottom: oSpacingByName('s6');
+	}
+}
+
+.consent-form__item-advisory-para {
+	margin-top: 0;
+	margin-bottom: oSpacingByName('s2');
+	&:last-child {
+		margin-bottom: 0;
+	}
+}

--- a/templates/components/yes-no-switch.html
+++ b/templates/components/yes-no-switch.html
@@ -25,7 +25,13 @@
 						{{#if checkedYes}} checked{{/if}}
 						{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}}
 					/>
-					<span class="o-forms-input__label" aria-hidden="true">Yes</span>
+					<span class="o-forms-input__label" aria-hidden="true">
+						{{#if toggleOnLabel}}
+							{{toggleOnLabel}}
+						{{else}}
+							Yes
+						{{/if}}
+					</span>
 				</label>
 				<label>
 					<input
@@ -38,7 +44,13 @@
 						data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-no"
 						{{#if checkedNo}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}}
 					/>
-					<span class="o-forms-input__label" aria-hidden="true">No</span>
+					<span class="o-forms-input__label" aria-hidden="true">
+						{{#if toggleOffLabel}}
+							{{toggleOffLabel}}
+						{{else}}
+							No
+						{{/if}}
+						</span>
 				</label>
 			</div>
 			<div class="o-forms-input__state" aria-hidden="false" aria-live="polite"></div>


### PR DESCRIPTION
This fixes up a few things missed or not quite done right from the origami migration.

- Adds some removed styles back in as they were used downstream
- Fixes the error handling code to work
- Uses the label text if passed in for toggle radios

There is also a lot of whitespace changes which were auto generated, not sure what caused that.