### PR TITLE
Add `for` to label tags

### DIFF
--- a/templates/components/yes-no-switch.html
+++ b/templates/components/yes-no-switch.html
@@ -13,7 +13,7 @@
 		</span>
 		<span class="o-forms-input o-forms-input--radio-box">
 			<div class="o-forms-input--radio-box__container">
-				<label>
+				<label for="{{{category}}}-{{{channel}}}-yes">
 					<input
 						type="radio"
 						name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}"
@@ -33,7 +33,7 @@
 						{{/if}}
 					</span>
 				</label>
-				<label>
+				<label for="{{{category}}}-{{{channel}}}-no">
 					<input
 						type="radio"
 						name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}"


### PR DESCRIPTION
In the origami change the labels lost their for attributes as the label
now wraps the input. This ensures that all label tags have a appropriate
for attribute which points at the input they are targeting. Having both
a for attribute and wrapping the input is valid.

This was primarily picked up due to the end to end tests trying to find
the input for a radio button to click.