### PR TITLE
Add margin to bottom of consent box 🐿 v2.12.5

### DIFF
--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -14,6 +14,7 @@ $two-thirds-width: percentage(2 / 3);
 .consent-form {
 	@include oTypographySans;
 	color: oColorsByName('black-80');
+	margin-bottom: oSpacingByName('s6');
 	max-width: none;
 	padding-left: 0;
 	padding-right: 0;


### PR DESCRIPTION
- Add margin bottom to consent box to offset new terms and conditions.

[ticket](https://financialtimes.atlassian.net/browse/AC-112?atlOrigin=eyJpIjoiYjJiMzNjYzBmZTQ5NGFmNzkxNWQ3NDEwMDQ5ZDdiYWMiLCJwIjoiaiJ9)

### Screenshots

| Before | After |
| -- | -- |
| <img width="710" alt="image" src="https://user-images.githubusercontent.com/7748470/74549042-d6e72900-4f46-11ea-901a-388508cf43ee.png"> | <img width="710" alt="image" src="https://user-images.githubusercontent.com/7748470/74549372-6e4c7c00-4f47-11ea-8844-9255f2ce18c4.png"> |