### PR TITLE
Fix unfound type definition file errors

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -18,10 +18,8 @@
     "types": [
       "agent-base",
       "body-parser",
-      "bunyan",
       "connect",
       "debug",
-      "events",
       "express",
       "express-serve-static-core",
       "glob",
@@ -34,7 +32,6 @@
       "node",
       "normalize-package-data",
       "range-parser",
-      "restify",
       "semver",
       "serve-static",
       "sinon",


### PR DESCRIPTION
Running `tsc -p tsconfig.commonjs.json` results in:

```
error TS2688: Cannot find type definition file for 'bunyan'.

error TS2688: Cannot find type definition file for 'events'.

error TS2688: Cannot find type definition file for 'restify'.
```

`tsconfig.esm.json`: `compilerOptions.types` are a:
> List of names of type definitions to include. See [@types, –typeRoots and –types](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types) for more details.

> If types is specified, only packages listed will be included. For instance:

```
{
   "compilerOptions": {
       "types" : ["node", "lodash", "express"]
   }
}
```

> This `tsconfig.json` file will *only* include `./node_modules/@types/node`, `./node_modules/@types/lodash` and `./node_modules/@types/express`. Other packages under `node_modules/@types/*` will not be included.

Currently the TypeScript compiler is looking for these `@types` directories that no longer exist. They were never included as dependencies in this repo (i.e. a search for their names only mentions their inclusion in the file from which this PR removes them), and so my guess is that they must have previously been dependencies of third party code which now no longer uses them.

Removing them (as is done in this PR) allows the `make build` task to complete.

#### References:
- [TypeScript: Compiler Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html).
- [TypeScript: tsconfig.json - @types, –typeRoots and –types](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).