### PR TITLE
Add @Financial-Times/ads team as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://help.github.com/articles/about-codeowners/ for more information about this file.
+
+* @financial-times/ads

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @financial-times/ads
+* @Financial-Times/ads


### PR DESCRIPTION
This PR specifies the Ads team as owners of this repo.

Follows up the request made by me in https://github.com/Financial-Times/n-profile-ui/pull/76.