### PR TITLE
Add missing type definitions

### DIFF
--- a/dist/commonjs/client/consent.js
+++ b/dist/commonjs/client/consent.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.ConsentForm = void 0;
 const helpers_1 = require('../helpers');
 class ConsentForm {
 	constructor (opts) {

--- a/dist/commonjs/client/live-update.js
+++ b/dist/commonjs/client/live-update.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.LiveUpdateConsent = void 0;
 const consent_1 = require('./consent');
 class LiveUpdateConsent extends consent_1.ConsentForm {
 	constructor (opts) {

--- a/dist/commonjs/client/main.js
+++ b/dist/commonjs/client/main.js
@@ -1,12 +1,13 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.helpers = exports.ConsentMessage = exports.UpdateConsentOnSave = exports.LiveUpdateConsent = exports.Reconsent = void 0;
 const reconsent_1 = require('./reconsent');
-exports.Reconsent = reconsent_1.Reconsent;
+Object.defineProperty(exports, 'Reconsent', { enumerable: true, get: function () { return reconsent_1.Reconsent; } });
 const live_update_1 = require('./live-update');
-exports.LiveUpdateConsent = live_update_1.LiveUpdateConsent;
+Object.defineProperty(exports, 'LiveUpdateConsent', { enumerable: true, get: function () { return live_update_1.LiveUpdateConsent; } });
 const update_on_save_1 = require('./update-on-save');
-exports.UpdateConsentOnSave = update_on_save_1.UpdateConsentOnSave;
+Object.defineProperty(exports, 'UpdateConsentOnSave', { enumerable: true, get: function () { return update_on_save_1.UpdateConsentOnSave; } });
 const message_1 = require('./message');
-exports.ConsentMessage = message_1.ConsentMessage;
+Object.defineProperty(exports, 'ConsentMessage', { enumerable: true, get: function () { return message_1.ConsentMessage; } });
 const helpers = require('../helpers');
 exports.helpers = helpers;

--- a/dist/commonjs/client/message.js
+++ b/dist/commonjs/client/message.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.ConsentMessage = void 0;
 const o_message_1 = require('o-message');
 class ConsentMessage {
 	constructor (options) {

--- a/dist/commonjs/client/reconsent.js
+++ b/dist/commonjs/client/reconsent.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.Reconsent = void 0;
 const update_on_save_1 = require('./update-on-save');
 class Reconsent extends update_on_save_1.UpdateConsentOnSave {
 	constructor (opts) {

--- a/dist/commonjs/client/update-on-save.js
+++ b/dist/commonjs/client/update-on-save.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.UpdateConsentOnSave = void 0;
 const consent_1 = require('./consent');
 const helpers_1 = require('../helpers');
 class UpdateConsentOnSave extends consent_1.ConsentForm {

--- a/dist/commonjs/helpers.js
+++ b/dist/commonjs/helpers.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.buildConsentRecord = exports.validateConsent = exports.populateConsentModel = exports.decorateChannel = exports.extractMetaFromString = exports.isConsentField = void 0;
 const Rx = /\b(lbi|consent)-(\w+)-(\w+)\b/;
 function isConsentField (name) {
 	return Rx.test(name);

--- a/dist/commonjs/server/main.js
+++ b/dist/commonjs/server/main.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+exports.helpers = exports.getFormOfWords = void 0;
 require('isomorphic-fetch');
 const helpers = require('../helpers');
 exports.helpers = helpers;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/jest": "^22.2.3",
     "@types/node": "^9.6.6",
     "@types/sinon": "^4.3.1",
+    "@types/xml2js": "0.4.5",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
TypeScript refuses to build because of missing type definitions for `xml2js`, causing nightlies to fail. This PR fixes the issue.