### PR TITLE
ACQ-932 New Consent Lite component 

### DIFF
--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import {
+	ConsentHeading,
+	FOWHiddenInputs,
+} from './';
+import { FowAPI } from '../../types/fow-api';
+
+interface Props {
+	showHeading: boolean;
+	showSubmitButton: boolean;
+	isSubsection: boolean;
+	formOfWords: FowAPI.Fow;
+	label: string;
+}
+
+const ConsentFields = ({ formOfWords }) => (
+		<div className="consent-form__section-wrapper">
+			<div className="o-forms-field">
+				<span className="o-forms-input o-forms-input--checkbox">
+					{formOfWords.consents &&
+						formOfWords.consents.map(
+						({ category, label }) => (
+							<CheckBox
+								label={label}
+								category={category}
+							/>
+						))
+					}
+				</span>
+			</div>
+		</div>
+);
+
+const CheckBox = ({ label, category}) => {
+	return(
+        <label htmlFor={`${category}`}>
+            <input
+				id={`${category}`}
+				type="checkbox"
+				name={`consent-${category}-byEmail}`}
+				value="yes"
+				checked
+			/>
+			<span className="o-forms-input__label">{label}</span>
+        </label>
+	);
+};
+
+const MoreInfo = () => (
+	<div className="consent-form__consent-info-para">
+		For more information about how we use your data, please refer to our
+		<a className="consent-form__link--external"
+			href="http://help.ft.com/help/legal-privacy/privacy/"
+			target="_blank">&nbsp;privacy</a>
+		&nbsp;and
+		<a className="consent-form__link--external"
+			href="http://help.ft.com/help/legal-privacy/cookies/"
+			target="_blank">&nbsp;cookie</a>
+		&nbsp;policies.
+	</div>
+);
+
+const Footer = () => (
+	<div className="manage-account-footer">
+		<div>Need to change anything?</div>
+		<a href="https://www.ft.com/myft/alerts">Manage your account</a>
+	</div>
+);
+
+const SubmitButton = ({ formOfWords }) => (
+	<div className="consent-form__submit-wrapper">
+		<button
+			type="submit"
+			className="consent-form__submit o-buttons o-buttons--primary o-buttons--big"
+		>
+			{formOfWords.copy && formOfWords.copy.submitButton
+				? formOfWords.copy.submitButton
+				: 'Start Reading'}
+		</button>
+	</div>
+);
+
+const ConsentLite = ({
+	showHeading,
+	isSubsection,
+	formOfWords,
+	showSubmitButton,
+}: Props) => (
+	<>
+		{showHeading && formOfWords.copy && (
+			<>
+				<ConsentHeading isSubsection={isSubsection}>
+					<>
+						{formOfWords.copy.heading1}
+						{formOfWords.copy.straplineHeading && (
+							<span className="consent-form__heading-strapline">
+								{formOfWords.copy.straplineHeading}
+							</span>
+						)}
+					</>
+				</ConsentHeading>
+				<div className="consent-form__intro-text">
+					{formOfWords.copy.straplineSmall &&
+						formOfWords.copy.straplineSmall}
+				</div>
+			</>
+		)}
+		<FOWHiddenInputs formOfWords={formOfWords} />
+		<div className="consent-form">
+			<ConsentFields formOfWords={formOfWords} />
+			<MoreInfo />
+			{showSubmitButton && (
+				<SubmitButton formOfWords={formOfWords} />
+			)}
+			<Footer />
+		</div>
+	</>
+);
+
+export default ConsentLite;

--- a/src/js/server/components/index.ts
+++ b/src/js/server/components/index.ts
@@ -8,5 +8,7 @@ export { default as Subheading } from './Subheading';
 export { default as YesNoSwitch } from './YesNoSwitch';
 
 export { default as Consent } from './Consent';
+export { default as ConsentLite } from './ConsentLite';
+
 export { default as Overlay } from './Overlay';
 export { default as Settings } from './Settings';


### PR DESCRIPTION
This is a new Consent Lite component. See the picture below where it is loaded through next-subscribe when referencing this component. 
<img width="528" alt="Screenshot 2021-05-04 at 08 47 36" src="https://user-images.githubusercontent.com/14136353/116977812-c7264280-acba-11eb-9fd9-7a4a13cd6225.png">

Any style changes would not be picked up as the frontend assets are pulled by bower and it uses v12 therefore style changes are done on next-subscribe. 

Once this PR is merged, next-subscribe PR with the reference to the new version will be created. 
