### PR TITLE
ACQ-932: fixing ConsentFields component

### DIFF
--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -19,32 +19,31 @@ const ConsentFields = ({ formOfWords }) => (
 			<span className="o-forms-input o-forms-input--checkbox">
 				{formOfWords.consents &&
 					formOfWords.consents.map(
-						({ category, label }) => {
-							if (category && label) (
-								<CheckBox
-									label={label}
-									category={category}
-								/>
-							)
-						})
+						({ category, label }) => (
+							<CheckBox
+								label={label}
+								category={category}
+							/>
+						)
+					)
 				}
 			</span>
 		</div>
 	</div>
 );
 
-const CheckBox = ({ label, category}) => {
-	return(
-        <label htmlFor={category}>
-            <input
+const CheckBox = ({ label, category }) => {
+	return (
+		<label htmlFor={category}>
+			<input
 				id={category}
 				type="checkbox"
-				name={`consent-${category}-byEmail}`}
+				name={`consent-${category}-byEmail`}
 				value="yes"
 				checked
 			/>
 			<span className="o-forms-input__label">{label}</span>
-        </label>
+		</label>
 	);
 };
 


### PR DESCRIPTION
### Description
There was an `if (category && label)` condition that prevents rendering the fields because it hasn't the `return`. There was two options here, first is to add the `return` sentence or just remove the conditional. I prefer the second because is easier for engineers to detect if the component is receiving wrong values, otherwise is hard to find why the fields are not shown.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-932

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/13876273/119640210-aa43e180-be18-11eb-939c-ae108c479379.png) | ![image](https://user-images.githubusercontent.com/13876273/119640280-be87de80-be18-11eb-9d26-8c85ae0d3aa1.png) |