### PR TITLE
ACQ-922: Adding missing class name to be used later on next-subscribe

### DIFF
--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -73,7 +73,7 @@ const SubmitButton = ({ formOfWords }) => (
 	<div className="consent-form__submit-wrapper">
 		<button
 			type="submit"
-			className="consent-form__submit o-buttons o-buttons--primary o-buttons--big"
+			className="consent-form__submit o-buttons o-buttons--primary o-buttons--big ncf__button--submit"
 		>
 			{formOfWords.copy && formOfWords.copy.submitButton
 				? formOfWords.copy.submitButton


### PR DESCRIPTION
### Description
In order to add tracking to the consent page on next-subscribe, the submit button of this component needs an additional class name that its used to load the button on client side.

```
submit.js:28 Uncaught (in promise) Error: Please include the submit button partial on the page
    at new e (submit.js:28)
    at new e (controller.js:48)
    at main.js:19
```
https://github.com/Financial-Times/next-subscribe/blob/main/client/controller.js#L48
https://github.com/Financial-Times/n-conversion-forms/blob/main/utils/submit.js#L25-L29

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-922