### PR TITLE
ACQ-1007: update copy for moreinfo field on consent lite component

### DIFF
--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -67,7 +67,7 @@ const MoreInfo = ({ formOfWords }) => {
 	switch (formOfWords.moreInfoCustom) {
 		case 'inArticleSignUp':
 			return <div className="consent-form__consent-info-para">
-				Full
+				By signing up for this email, you are registering for a free account with the FT. Full
 				<a className="consent-form__link--external"
 					href="http://help.ft.com/help/legal-privacy/terms-conditions/"
 					target="_blank">&nbsp;Terms and Conditions</a>


### PR DESCRIPTION
Updating wording for consent lite component moreinfo field. Following designer recommendations  [here](https://financialtimes.slack.com/archives/C024DRXH65A/p1624964141000800?thread_ts=1624909422.002300&cid=C024DRXH65A).

Ticket https://financialtimes.atlassian.net/browse/ACQ-1007

![image](https://user-images.githubusercontent.com/48696369/123856556-9e57ad80-d8f7-11eb-9283-0953a243cb16.png)
