### PR TITLE
ADSDEV-1052 restore handlebars templates

### DIFF
--- a/templates/banner.html
+++ b/templates/banner.html
@@ -1,0 +1,14 @@
+<div class="consent-banner" data-consent-component="consent-banner">
+	<div class="consent-banner__outer">
+		<div class="consent-banner__inner" data-consent-banner-inner="">
+			<div class="consent-banner__content">
+				<p><strong>Don’t lose touch with the FT.</strong> Check your Contact Preferences.</p>
+			</div>
+			<div class="consent-banner__actions">
+				<div class="consent-banner__action">
+					<button type="button" class="consent-banner__button">Check your preferences</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/components/changes-saved-message.html
+++ b/templates/components/changes-saved-message.html
@@ -1,0 +1,13 @@
+<div class="consent-message-demo">
+	<div class="o-message o-message--alert o-message--inner o-message--success" data-o-component="o-message">
+		<div class="o-message__container">
+			<div class="o-message__content">
+				<p class="o-message__content-main">
+					<span class="o-message__content-highlight">
+						Your changes have been saved.
+					</span>
+				</p>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/components/error-message-core.html
+++ b/templates/components/error-message-core.html
@@ -1,0 +1,46 @@
+<div class="o-message o-message--alert o-message--inner o-message--error" data-o-component="o-message">
+	<div class="o-message__container">
+		<div class="o-message__content">
+			<p class="o-message__content-main">
+				<span class="o-message__content-highlight consent-message__content-block">
+					{{#if highlight}}
+						{{{highlight}}}
+					{{else}}
+						Your Contact Preferences couldn't be saved.
+					{{/if}}
+				</span>
+				{{#unless hideDetail}}
+				<span class="o-message__content-detail">
+					{{#if detail}}
+						{{{detail}}}
+					{{else}}
+						These can be set anytime in myFT.
+					{{/if}}
+				</span>
+				{{/unless}}
+			</p>
+			{{#if additional}}
+			<p class="o-message__content--additional">
+				{{{additional}}}
+			</p>
+			{{/if}}
+			{{#with actions}}
+			<div class="o-message__actions">
+				{{#with primary}}
+					<a href="{{{url}}}" class="o-message__actions__primary">{{{text}}}</a>
+				{{/with}}
+				{{#with secondary}}
+					<a href="{{{url}}}" class="o-message__actions__secondary">{{{text}}}</a>
+				{{/with}}
+			</div>
+			{{else}}
+				{{#unless hideActions}}
+				<div class="o-message__actions">
+					<a href="/myft/alerts/" class="o-message__actions__primary">Visit Contact Preferences</a>
+					<a href="https://help.ft.com/" class="o-message__actions__secondary">Help centre</a>
+				</div>
+				{{/unless}}
+			{{/with}}
+		</div>
+	</div>
+</div>

--- a/templates/components/fow-hidden-inputs.html
+++ b/templates/components/fow-hidden-inputs.html
@@ -1,0 +1,3 @@
+<input type="hidden" name="formOfWordsId" value="{{formOfWords.id}}" />
+<input type="hidden" name="formOfWordsScope" value="{{formOfWords.scope}}" />
+<input type="hidden" name="consentSource" value="{{formOfWords.source}}" />

--- a/templates/components/overlay.html
+++ b/templates/components/overlay.html
@@ -1,0 +1,13 @@
+<script type="text/template" id="overlay-gdpr-consent"></script>
+<div class="consent-form-content">
+	<button type="button" class="o-overlay__close">Ask later</button>
+	<div class="consent-form-content__inner">
+		<form class="consent-form consent-form--scrollable">
+			{{>n-profile-ui/templates/consent}}
+		</form>
+		<div class="consent-confirmation hidden">
+			{{>n-profile-ui/templates/confirmation}}
+		</div>
+	</div>
+</div>
+{{>n-profile-ui/templates/banner}}

--- a/templates/components/yes-no-switch.html
+++ b/templates/components/yes-no-switch.html
@@ -1,0 +1,62 @@
+<fieldset class="consent-form__fieldset">
+	<legend class="o-normalise-visually-hidden">{{label}}</legend>
+	<div class="o-forms-field o-forms-field--inline">
+		<span class="o-forms-title">
+			<span class="o-forms-title__main" id="legend-{{{category}}}-{{{channel}}}" aria-hidden="true">
+				{{label}}
+			</span>
+			{{#if advisory}}
+			<div class="consent-form__item-advisory">
+				{{{advisory}}}
+			</div>
+			{{/if}}
+		</span>
+		<span class="o-forms-input o-forms-input--radio-box">
+			<div class="o-forms-input--radio-box__container">
+				<label for="{{{category}}}-{{{channel}}}-yes">
+					<input
+						type="radio"
+						name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}"
+						value="yes"
+						aria-label="{{#if toggleOnLabel}}{{toggleOnLabel}}{{else}}yes{{/if}}"
+						class="consent-form__radio-button{{#if inputClass}} {{inputClass}}{{/if}}"
+						id="{{{category}}}-{{{channel}}}-yes"
+						aria-describedby="legend-{{{category}}}-{{{channel}}}"
+						data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-yes"
+						{{#if checkedYes}} checked{{/if}}
+						{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}}
+					/>
+					<span class="o-forms-input__label" aria-hidden="true">
+						{{#if toggleOnLabel}}
+							{{toggleOnLabel}}
+						{{else}}
+							Yes
+						{{/if}}
+					</span>
+				</label>
+				<label for="{{{category}}}-{{{channel}}}-no">
+					<input
+						type="radio"
+						name="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}"
+						value="no"
+						aria-label="{{#if toggleOffLabel}}{{toggleOffLabel}}{{else}}no{{/if}}"
+						class="consent-form__radio-button consent-form__radio-button--negative"
+						id="{{{category}}}-{{{channel}}}-no"
+						aria-describedby="legend-{{{category}}}-{{{channel}}}"
+						data-trackable="{{#if lbi}}lbi{{else}}consent{{/if}}-{{{category}}}-{{{channel}}}-no"
+						{{#if checkedNo}} checked{{/if}}{{#each elementAttrs}} {{{name}}}{{#if value}}="{{{value}}}"{{/if}}{{/each}}
+					/>
+					<span class="o-forms-input__label" aria-hidden="true">
+						{{#if toggleOffLabel}}
+							{{toggleOffLabel}}
+						{{else}}
+							No
+						{{/if}}
+						</span>
+				</label>
+			</div>
+			<div class="o-forms-input__state" aria-hidden="false" aria-live="polite"></div>
+			<div class="o-forms-input__error">There was a problem saving, please try later.</div>
+		</span>
+	</div>
+</fieldset>

--- a/templates/confirmation.html
+++ b/templates/confirmation.html
@@ -1,0 +1,11 @@
+<h2 class="consent-form__heading-level-3 margin-bottom-x3">Thank you<br/>We've updated your preferences</h2>
+<div class="consent-form__consent-info margin-top-x8" data-trackable="customer-message">
+	We'll still send you service messages about your account, security or legal notifications.
+</div>
+<div class="consent-form__confirm-opt-in">
+	You can opt-in to other emails from the FT or change what you receive by visiting the <a class="link-external" href="#">Preferences centre</a>
+</div>
+
+<div class="consent-form__submit-wrapper">
+	<a href="{{redirect}}" class="consent-form__close o-buttons o-buttons--primary o-buttons--big">Continue to FT.com</a>
+</div>

--- a/templates/consent.html
+++ b/templates/consent.html
@@ -1,0 +1,67 @@
+{{#if showHeading}}
+{{#if isSubsection}}
+<h2 class="consent-form__heading-level-1">
+{{else}}
+<h1 class="consent-form__heading-level-1">
+	{{/if}}
+	{{formOfWords.copy.heading1}}
+	{{#if formOfWords.copy.straplineHeading}}
+	<span class="consent-form__heading-strapline">{{formOfWords.copy.straplineHeading}}</span>
+	{{/if}}
+{{#if isSubsection}}</h2>{{else}}
+</h1>{{/if}}
+<div class="consent-form__intro-text">
+	{{#if formOfWords.copy.straplineSmall}}
+	{{formOfWords.copy.straplineSmall}}
+	{{/if}}
+</div>
+{{/if}}
+
+{{#with formOfWords.error}}
+<div class="consent-message-demo consent-message-demo--error margin-bottom-x5">
+	{{>n-profile-ui/templates/components/error-message-core error=formOfWords.error}}
+</div>
+{{/with}}
+
+{{>n-profile-ui/templates/components/fow-hidden-inputs }}
+<div name="consent" class="consent-form">
+	<div class="consent-form__section-wrapper">
+		{{#each formOfWords.consents}}
+		<div class="consent-form__section">
+			{{#if ../isSubsection}}
+			<h3 class="consent-form__heading-level-3">
+				{{heading}}
+			</h3>
+			{{else}}
+			<h2 class="consent-form__heading-level-3">
+				{{heading}}
+			</h2>
+			{{/if}}
+			<div class="consent-form__section-label consent-form__limit-width">
+				{{label}}
+			</div>
+			<div class="consent-form__switches-group">
+				{{#each channels}}
+				{{>n-profile-ui/templates/components/yes-no-switch category=../category}}
+				{{/each}}
+			</div>
+		</div>
+		{{/each}}
+	</div>
+	{{#if formOfWords.copy.serviceMessagesInfo}}
+	<div class="consent-form__consent-info margin-top-x8">
+		{{{formOfWords.copy.serviceMessagesInfo}}}
+	</div>
+	{{/if}}
+	{{#if showSubmitButton}}
+	<div class="consent-form__submit-wrapper">
+		<button type="submit" class="consent-form__submit o-buttons o-buttons--primary o-buttons--big">
+			{{#if formOfWords.copy.submitButton}}
+			{{{formOfWords.copy.submitButton}}}
+			{{else}}
+			Confirm
+			{{/if}}
+		</button>
+	</div>
+	{{/if}}
+</div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,58 @@
+{{#if formOfWords.copy.heading1}}
+<h1 class="consent-form__heading-level-1">
+	{{formOfWords.copy.heading1}}
+</h1>
+{{/if}}
+{{#if changesSaved}}
+<div class="t-settings-saved margin-top-x4 margin-bottom-x5">
+	{{>n-profile-ui/templates/components/changes-saved-message}}
+</div>
+{{/if}}
+
+{{#with formOfWords.error}}
+<div class="t-settings-error consent-message-demo consent-message-demo--error margin-top-x4 margin-bottom-x5">
+	{{>n-profile-ui/templates/components/error-message-core error=formOfWords.error}}
+</div>
+{{/with}}
+{{#if formOfWords.copy.straplineSmall}}
+<div class="consent-form__intro-text">
+	{{{formOfWords.copy.straplineSmall}}}
+</div>
+{{/if}}
+{{>n-profile-ui/templates/components/fow-hidden-inputs }}
+<div name="consent" class="consent-form">
+	{{#each formOfWords.consents}}
+	<div class="margin-bottom-x6">
+		{{> n-profile-ui/templates/subheading
+			text=label
+			linkText=linkText
+			linkUrl=linkUrl
+			subheadingLevel=subheadingLevel}}
+		<div>
+			{{#each channels}}
+			{{>n-profile-ui/templates/components/yes-no-switch
+				category=../category
+				toggleOnLabel=../../toggleOnLabel
+				toggleOffLabel=../../toggleOffLabel
+			}}
+			{{/each}}
+		</div>
+	</div>
+	{{/each}}
+	{{#if formOfWords.copy.submitPreamble}}
+	{{{formOfWords.copy.submitPreamble}}}
+	{{/if}}
+	{{#if showSubmitButton}}
+		{{#unless formOfWords.error}}
+		<div class="consent-form__submit-wrapper">
+			<button type="submit" class="consent-form__submit o-buttons o-buttons--primary o-buttons--big">
+				{{#if formOfWords.copy.submitButton}}
+				{{{formOfWords.copy.submitButton}}}
+				{{else}}
+				Confirm
+				{{/if}}
+			</button>
+		</div>
+		{{/unless}}
+	{{/if}}
+</div>

--- a/templates/subheading.html
+++ b/templates/subheading.html
@@ -1,0 +1,8 @@
+<div class="flex-row flex-row--align-baseline{{#ifEquals linkAlign 'right'}} flex-row--justify-between{{/ifEquals}} subheading {{#if subheadingLevel}} subheading--level-{{subheadingLevel}}{{/if}}">
+	<h2 class="flex-row__cell-grow subheading__title">
+		{{{text}}}
+	</h2>
+	{{#ifSome linkText @root.flags.hideOutboundLinks}}
+	<a class="subheading__link" href="{{linkUrl}}" target="_blank" rel="noopener" aria-label="{{linkAriaLabel}}" data-trackable="{{trackable}}">{{linkText}}</a>
+	{{/ifSome}}
+</div>


### PR DESCRIPTION
### Context
* Handlebars templates were removed in [v13 Handlebars to JSX](https://github.com/Financial-Times/n-profile-ui/releases/tag/v13.0.2) - see related PR https://github.com/Financial-Times/n-profile-ui/pull/71.
* A few active repositories have not migrated yet to v13, and are still using the handlebars templates from n-profile-ui < v12, including `next-control-centre`.
* We have to release a new major version of `n-profile-ui` where all the Origami bower components have been removed and replaced by their equivalent npm version.

### Description
Restores the handlebars templates which have been removed in v13 and are still needed in `next-control-centre` and a few other active repos.