### PR TITLE
ACQ 1472 Full width to the consent label

### DIFF
--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -93,7 +93,7 @@ const Consent = ({
 								isSubsection={isSubsection}
 								showToggleSwitch={showToggleSwitch}
 							/>
-							<div className="consent-form__section-label consent-form__limit-width">
+							<div className="consent-form__section-label consent-form__full-width">
 								{label}
 							</div>
 							<div className={`${formFieldsClassName(showToggleSwitch)}`}>

--- a/src/scss/form.scss
+++ b/src/scss/form.scss
@@ -46,9 +46,9 @@ $two-thirds-width: percentage(2 / 3);
 		}
 	}
 
-	.consent-form__limit-width {
+	.consent-form__full-width {
 		@include oGridRespondTo(M) {
-			width: 80%;
+			width: 100%;
 		}
 	}
 

--- a/templates/consent.html
+++ b/templates/consent.html
@@ -37,7 +37,7 @@
 				{{heading}}
 			</h2>
 			{{/if}}
-			<div class="consent-form__section-label consent-form__limit-width">
+			<div class="consent-form__section-label consent-form__full-width">
 				{{label}}
 			</div>
 			<div class="consent-form__switches-group">


### PR DESCRIPTION
One example where the label is using the 80% of width under `Top stories and featuress`

<img width="715" alt="Screenshot 2022-04-21 at 08 48 51" src="https://user-images.githubusercontent.com/36263/164406187-3969cdd4-607c-46fe-8b64-6e3abe1bfa3f.png">

With this change it will be using 100% width 
<img width="653" alt="Screenshot 2022-04-21 at 08 49 14" src="https://user-images.githubusercontent.com/36263/164406170-ffd42159-c729-4aa2-854d-d54867f57398.png">

