### PR TITLE
ADSDEV-1052 Remove unused n-internal-tool dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@financial-times/dotcom-build-sass": "^4.1.0",
     "@financial-times/n-gage": "8.3.2",
-    "@financial-times/n-internal-tool": "8.0.0",
     "@types/classnames": "^2.2.9",
     "@types/express": "4.17.13",
     "@types/jest": "27.0.2",


### PR DESCRIPTION
## Meta
Jira: [ADSDEV-1052](https://financialtimes.atlassian.net/browse/ADSDEV-1052)

## Description
`n-profile-ui` installs the `n-internal-tool` via `package.json`.
`n-internal-tools` uses an old version Origami build string, and it's also not required anymore by `n-profile-ui`; the dependency was previously used to spin up the demos.
Therefore, we can uninstall `n-internal-tool` from `n-profile-ui`.