### PR TITLE
Add ID and ARIA tags to labels and input

### DIFF
--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -39,17 +39,17 @@ const ToggleSwitch = ({ lbi, label, category, channel }) => {
 		<label id={`${category}-${channel}`}>
 			<input
 				id={`input-${category}-${channel}`}
-                aria-labelledby={`${category}-${channel}`}
+				aria-labelledby={`${category}-${channel}`}
 				name={`${lbi ? 'lbi' : 'consent'}-${category}-${channel}`}
 				type="checkbox"
 				value="yes"
-                defaultChecked
+				defaultChecked
 			/>
-            <span
-                className="o-forms-input__label"
-                aria-labelledby={`${category}-${channel}`}>
-                    {label}
-            </span>
+			<span
+				className="o-forms-input__label"
+				aria-labelledby={`${category}-${channel}`}>
+					{label}
+			</span>
 		</label>
 	);
 };

--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -36,16 +36,20 @@ const ChannelHeading = ({ heading, isSubsection, showToggleSwitch }) => {
 
 const ToggleSwitch = ({ lbi, label, category, channel }) => {
 	return (
-		<label htmlFor={`${category}-${channel}`}>
+		<label id={`${category}-${channel}`}>
 			<input
-				aria-labelledby={`${category}-${channel}`}
-				data-testid={`input-${category}-${channel}`}
+				id={`input-${category}-${channel}`}
+                aria-labelledby={`${category}-${channel}`}
 				name={`${lbi ? 'lbi' : 'consent'}-${category}-${channel}`}
 				type="checkbox"
 				value="true"
-				defaultChecked
+                checked
 			/>
-			<span className="o-forms-input__label">{label}</span>
+            <span
+                className="o-forms-input__label"
+                aria-labelledby={`${category}-${channel}`}>
+                    {label}
+            </span>
 		</label>
 	);
 };

--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -43,7 +43,7 @@ const ToggleSwitch = ({ lbi, label, category, channel }) => {
 				name={`${lbi ? 'lbi' : 'consent'}-${category}-${channel}`}
 				type="checkbox"
 				value="true"
-                checked
+                defaultChecked
 			/>
             <span
                 className="o-forms-input__label"

--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -42,7 +42,7 @@ const ToggleSwitch = ({ lbi, label, category, channel }) => {
                 aria-labelledby={`${category}-${channel}`}
 				name={`${lbi ? 'lbi' : 'consent'}-${category}-${channel}`}
 				type="checkbox"
-				value="true"
+				value="yes"
                 defaultChecked
 			/>
             <span

--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -36,12 +36,13 @@ const ChannelHeading = ({ heading, isSubsection, showToggleSwitch }) => {
 
 const ToggleSwitch = ({ lbi, label, category, channel }) => {
 	return (
-		<label>
+		<label htmlFor={`${category}-${channel}`}>
 			<input
-				id={`${category}-${channel}`}
+				aria-labelledby={`${category}-${channel}`}
+				data-testid={`input-${category}-${channel}`}
 				name={`${lbi ? 'lbi' : 'consent'}-${category}-${channel}`}
 				type="checkbox"
-				value="yes"
+				value="true"
 				defaultChecked
 			/>
 			<span className="o-forms-input__label">{label}</span>


### PR DESCRIPTION
Add ID and ARIA tags to labels and input. This will help us to solve 2 purposes one easy-to-get E2E test by having unique IDs and making interactive elements more accessible.

Ticket: https://financialtimes.atlassian.net/browse/ACQ-1658
