### PR TITLE
ACQ 1972: Consent Lite Footer  

### DIFF
--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -121,19 +121,11 @@ const MoreInfo = ({ formOfWords }) => {
 	}
 };
 
-// const Footer = ({ serviceMessagesInfo }) =>
-// 	serviceMessagesInfo || (
-// 		<div className="manage-account-footer">
-// 			<div>Need to change anything?</div>
-// 			<a href="https://www.ft.com/myft/alerts">Manage your account</a>
-// 		</div>
-// 	);
-
 // serviceMessagesInfo is string
 // moreInfoCustom will be set for specific pages like Google register consent
-const Footer = ({ serviceMessagesInfo, moreInfoCustom }) =>
-    serviceMessagesInfo && moreInfoCustom !== 'inGoogleRegisterConsent'
-        ? serviceMessagesInfo
+const Footer = ({ formOfWords }) =>
+formOfWords.copy.serviceMessagesInfo && formOfWords.moreInfoCustom !== 'inGoogleRegisterConsent'
+        ? formOfWords.copy.serviceMessagesInfo
         : (
             <div className="manage-account-footer">
                 <div>Need to change anything?</div>
@@ -192,7 +184,7 @@ const ConsentLite = ({
 			{!showToggleSwitch && <MoreInfo formOfWords={formOfWords} />}
 			{showSubmitButton && <SubmitButton formOfWords={formOfWords} />}
 			{showFooter && (
-				<Footer serviceMessagesInfo={formOfWords.copy.serviceMessagesInfo} moreInfoCustom={formOfWords.moreInfoCustom} />
+				<Footer formOfWords={formOfWords} />
 			)}
 		</div>
 	</>

--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -121,17 +121,25 @@ const MoreInfo = ({ formOfWords }) => {
 	}
 };
 
-// serviceMessagesInfo is string
-// moreInfoCustom will be set for specific pages like Google register consent
-const Footer = ({ formOfWords }) =>
-formOfWords.copy.serviceMessagesInfo && formOfWords.moreInfoCustom !== 'inGoogleRegisterConsent'
-        ? formOfWords.copy.serviceMessagesInfo
-        : (
-            <div className="manage-account-footer">
-                <div>Need to change anything?</div>
-                <a href="https://www.ft.com/myft/alerts">Manage your account</a>
-            </div>
-        )
+/**
+ * moreInfoCustom will be set for specific pages like Google register consent
+ */
+export const Footer = ({ formOfWords }: { formOfWords: FowAPI.Fow }) => {
+  const showServiceMessage =
+    formOfWords.copy.serviceMessagesInfo &&
+    formOfWords.moreInfoCustom !== "inGoogleRegisterConsent";
+
+  if (showServiceMessage) {
+    return formOfWords.copy.serviceMessagesInfo;
+  }
+
+  return (
+    <div className="manage-account-footer">
+      <div>Need to change anything?</div>
+      <a href="https://www.ft.com/myft/alerts">Manage your account</a>
+    </div>
+  );
+};
 
 const SubmitButton = ({ formOfWords }) => (
 	<div className="consent-form__submit-wrapper">

--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -121,13 +121,25 @@ const MoreInfo = ({ formOfWords }) => {
 	}
 };
 
-const Footer = ({ serviceMessagesInfo }) =>
-	serviceMessagesInfo || (
-		<div className="manage-account-footer">
-			<div>Need to change anything?</div>
-			<a href="https://www.ft.com/myft/alerts">Manage your account</a>
-		</div>
-	);
+// const Footer = ({ serviceMessagesInfo }) =>
+// 	serviceMessagesInfo || (
+// 		<div className="manage-account-footer">
+// 			<div>Need to change anything?</div>
+// 			<a href="https://www.ft.com/myft/alerts">Manage your account</a>
+// 		</div>
+// 	);
+
+// serviceMessagesInfo is string
+// moreInfoCustom will be set for specific pages like Google register consent
+const Footer = ({ serviceMessagesInfo, moreInfoCustom }) =>
+    serviceMessagesInfo && moreInfoCustom !== 'inGoogleRegisterConsent'
+        ? serviceMessagesInfo
+        : (
+            <div className="manage-account-footer">
+                <div>Need to change anything?</div>
+                <a href="https://www.ft.com/myft/alerts">Manage your account</a>
+            </div>
+        )
 
 const SubmitButton = ({ formOfWords }) => (
 	<div className="consent-form__submit-wrapper">
@@ -180,7 +192,7 @@ const ConsentLite = ({
 			{!showToggleSwitch && <MoreInfo formOfWords={formOfWords} />}
 			{showSubmitButton && <SubmitButton formOfWords={formOfWords} />}
 			{showFooter && (
-				<Footer serviceMessagesInfo={formOfWords.copy.serviceMessagesInfo} />
+				<Footer serviceMessagesInfo={formOfWords.copy.serviceMessagesInfo} moreInfoCustom={formOfWords.moreInfoCustom} />
 			)}
 		</div>
 	</>

--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -130,7 +130,11 @@ export const Footer = ({ formOfWords }: { formOfWords: FowAPI.Fow }) => {
     formOfWords.moreInfoCustom !== "inGoogleRegisterConsent";
 
   if (showServiceMessage) {
-    return formOfWords.copy.serviceMessagesInfo;
+    return (
+        <>
+            {formOfWords.copy.serviceMessagesInfo}
+        </>
+    )
   }
 
   return (

--- a/src/js/types/fow-api.d.ts
+++ b/src/js/types/fow-api.d.ts
@@ -18,6 +18,7 @@ export namespace FowAPI {
 	export interface Fow {
 		scope: string;
 		id: string;
+		moreInfoCustom: string;
 		copy: {
 			serviceMessagesInfo: string;
 			heading1: string;

--- a/src/js/types/fow-api.d.ts
+++ b/src/js/types/fow-api.d.ts
@@ -18,7 +18,7 @@ export namespace FowAPI {
 	export interface Fow {
 		scope: string;
 		id: string;
-		moreInfoCustom: string;
+		moreInfoCustom?: string;
 		copy: {
 			serviceMessagesInfo: string;
 			heading1: string;


### PR DESCRIPTION
### Description: 
We have a google extended meter feature where we ask users to read more content via google, during this flow we ask the user to update consent preferences. We want to use the existing consent record which is 'consentB2CSignup' but with different variations in the footer for the google consent page.

### Ticket: https://financialtimes.atlassian.net/browse/ACQ-1972

### Screenshot:
Footer with the right message:

<img width="1440" alt="Screenshot 2022-11-10 at 12 01 24" src="https://user-images.githubusercontent.com/36263/201096544-08ad9fb7-9297-40c0-9f77-80b5605a4d9f.png">

 