### PR TITLE
Upgrade @financial-times/n-user-api-client 4.1.0 -> 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@financial-times/n-user-api-client": "4.1.0",
+        "@financial-times/n-user-api-client": "4.1.1",
         "classnames": "^2.2.6",
         "isomorphic-fetch": "3.0.0",
         "react": "^16.12.0"
@@ -2126,29 +2126,31 @@
       }
     },
     "node_modules/@financial-times/n-mask-logger": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-6.0.0.tgz",
-      "integrity": "sha512-Q6jm4sqkwhaFZAsXqTx4ZDvpHNddpyvl8SyCLgObMfWsZPKAEkYHQEw/vY91wOBs85iXNq3aybBiQasDYDXpmg==",
-      "deprecated": "this version of n-mask-logger is no longer supported. Please upgrade to the latest version",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-7.2.0.tgz",
+      "integrity": "sha512-Q1g9ilr9JFy3n+xRkxeyZkWzZ+jjYxg0j96q8I/BgIX9WJ/b5n0hbHkXLbg/lcGx1LYMMdnKpIlDKVQFBFaVow==",
+      "hasInstallScript": true,
       "dependencies": {
-        "@financial-times/n-logger": "^6.0.1"
+        "@financial-times/n-logger": "^10.2.0"
       },
       "engines": {
-        "node": "12.x"
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/n-mask-logger/node_modules/@financial-times/n-logger": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-      "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
-      "deprecated": "this version of n-logger is no longer supported. Please upgrade to the latest version",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
+      "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
+      "hasInstallScript": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
-        "node-fetch": "^2.6.0",
-        "winston": "^2.4.0"
+        "node-fetch": "^2.6.7",
+        "winston": "^2.4.6"
       },
       "engines": {
-        "node": ">=6.1.0"
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/n-mask-logger/node_modules/node-fetch": {
@@ -2215,12 +2217,12 @@
       }
     },
     "node_modules/@financial-times/n-user-api-client": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.0.tgz",
-      "integrity": "sha512-rV7a+rgjOcoIWr7S0QiptEAR5cX/xQfFvsSDFnc7aQI54JqIPhZrfJ3UU/BrMCPECVFYKvBjS1p+mE7zMiHG8A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.1.tgz",
+      "integrity": "sha512-TdkHx9Cp5P16DY4LmZl9az/4VJPNQ/b+Xklmok2AZW0adt+Xjduz9vqvsMIA9/YZu2sfjmHGBdAsFFPICUCU0Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@financial-times/n-mask-logger": "6.0.0",
+        "@financial-times/n-mask-logger": "7.2.0",
         "@financial-times/n-memb-gql-client": "2.2.3",
         "isomorphic-fetch": "^3.0.0",
         "querystring": "^0.2.0",
@@ -24833,21 +24835,21 @@
       }
     },
     "@financial-times/n-mask-logger": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-6.0.0.tgz",
-      "integrity": "sha512-Q6jm4sqkwhaFZAsXqTx4ZDvpHNddpyvl8SyCLgObMfWsZPKAEkYHQEw/vY91wOBs85iXNq3aybBiQasDYDXpmg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-mask-logger/-/n-mask-logger-7.2.0.tgz",
+      "integrity": "sha512-Q1g9ilr9JFy3n+xRkxeyZkWzZ+jjYxg0j96q8I/BgIX9WJ/b5n0hbHkXLbg/lcGx1LYMMdnKpIlDKVQFBFaVow==",
       "requires": {
-        "@financial-times/n-logger": "^6.0.1"
+        "@financial-times/n-logger": "^10.2.0"
       },
       "dependencies": {
         "@financial-times/n-logger": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-          "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
+          "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
           "requires": {
             "json-stringify-safe": "^5.0.1",
-            "node-fetch": "^2.6.0",
-            "winston": "^2.4.0"
+            "node-fetch": "^2.6.7",
+            "winston": "^2.4.6"
           }
         },
         "node-fetch": {
@@ -24898,11 +24900,11 @@
       }
     },
     "@financial-times/n-user-api-client": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.0.tgz",
-      "integrity": "sha512-rV7a+rgjOcoIWr7S0QiptEAR5cX/xQfFvsSDFnc7aQI54JqIPhZrfJ3UU/BrMCPECVFYKvBjS1p+mE7zMiHG8A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.1.tgz",
+      "integrity": "sha512-TdkHx9Cp5P16DY4LmZl9az/4VJPNQ/b+Xklmok2AZW0adt+Xjduz9vqvsMIA9/YZu2sfjmHGBdAsFFPICUCU0Q==",
       "requires": {
-        "@financial-times/n-mask-logger": "6.0.0",
+        "@financial-times/n-mask-logger": "7.2.0",
         "@financial-times/n-memb-gql-client": "2.2.3",
         "isomorphic-fetch": "^3.0.0",
         "querystring": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@financial-times/n-user-api-client": "4.1.0",
+    "@financial-times/n-user-api-client": "4.1.1",
     "classnames": "^2.2.6",
     "isomorphic-fetch": "3.0.0",
     "react": "^16.12.0"


### PR DESCRIPTION
Re. this PR comment: https://github.com/Financial-Times/next-newsletter-signup/pull/360#discussion_r1113327947

Creating a release with this change will allow next-newsletter-signup to include the requisite version of n-logger in its dependency tree.

The only breaking changes in [n-mask-logger v7](https://github.com/Financial-Times/n-mask-logger/releases/tag/v7.0.0) are dropped support for Node v12 and npm 6.

I will release this change as a patch.