### PR TITLE
Bump n-user-api-client to include Joi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@financial-times/n-user-api-client": "4.1.1",
+        "@financial-times/n-user-api-client": "4.1.2",
         "classnames": "^2.2.6",
         "isomorphic-fetch": "3.0.0",
         "react": "^16.12.0"
@@ -2217,14 +2217,15 @@
       }
     },
     "node_modules/@financial-times/n-user-api-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.1.tgz",
-      "integrity": "sha512-TdkHx9Cp5P16DY4LmZl9az/4VJPNQ/b+Xklmok2AZW0adt+Xjduz9vqvsMIA9/YZu2sfjmHGBdAsFFPICUCU0Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.2.tgz",
+      "integrity": "sha512-NSTQ5wEmxD0K2L+S929UMDlLxJEbHWDTmoJlzwg8vdVZ1L4xsuSlWahK+SODr88hUotYq6Cu+vxbvjqDpOzz8Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-mask-logger": "7.2.0",
         "@financial-times/n-memb-gql-client": "2.2.3",
         "isomorphic-fetch": "^3.0.0",
+        "joi": "10.6.0",
         "querystring": "^0.2.0",
         "ramda": "^0.27.1",
         "url": "^0.11.0"
@@ -9100,6 +9101,15 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -10235,6 +10245,14 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
+    "node_modules/isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha512-LPjFxaTatluwGAJlGe4FtRdzg0a9KlXrahHoHAR4HwRNf90Ttwi6sOQ9zj+EoCPmk9yyK+WFUqkm0imUo8UJbw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -10397,6 +10415,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/items": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
+      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg==",
+      "deprecated": "This module has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version of hapi to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial)."
     },
     "node_modules/iterate-iterator": {
       "version": "1.0.2",
@@ -12427,6 +12451,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/joi": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dependencies": {
+        "hoek": "4.x.x",
+        "isemail": "2.x.x",
+        "items": "2.x.x",
+        "topo": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/js-base64": {
@@ -21253,6 +21292,18 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha512-QMfJ9TC5lKcmLZImOZ/BTSWJeVbay7XK2nlzvFALW3BA5OkvBnbs0poku4EsRpDMndDVnM58EU/8D3ZcoVehWg==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dependencies": {
+        "hoek": "4.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
@@ -24900,13 +24951,14 @@
       }
     },
     "@financial-times/n-user-api-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.1.tgz",
-      "integrity": "sha512-TdkHx9Cp5P16DY4LmZl9az/4VJPNQ/b+Xklmok2AZW0adt+Xjduz9vqvsMIA9/YZu2sfjmHGBdAsFFPICUCU0Q==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-user-api-client/-/n-user-api-client-4.1.2.tgz",
+      "integrity": "sha512-NSTQ5wEmxD0K2L+S929UMDlLxJEbHWDTmoJlzwg8vdVZ1L4xsuSlWahK+SODr88hUotYq6Cu+vxbvjqDpOzz8Q==",
       "requires": {
         "@financial-times/n-mask-logger": "7.2.0",
         "@financial-times/n-memb-gql-client": "2.2.3",
         "isomorphic-fetch": "^3.0.0",
+        "joi": "10.6.0",
         "querystring": "^0.2.0",
         "ramda": "^0.27.1",
         "url": "^0.11.0"
@@ -30368,6 +30420,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -31188,6 +31245,11 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha512-LPjFxaTatluwGAJlGe4FtRdzg0a9KlXrahHoHAR4HwRNf90Ttwi6sOQ9zj+EoCPmk9yyK+WFUqkm0imUo8UJbw=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -31318,6 +31380,11 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "items": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
+      "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
     },
     "iterate-iterator": {
       "version": "1.0.2",
@@ -32806,6 +32873,17 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "requires": {
+        "hoek": "4.x.x",
+        "isemail": "2.x.x",
+        "items": "2.x.x",
+        "topo": "2.x.x"
       }
     },
     "js-base64": {
@@ -39820,6 +39898,14 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha512-QMfJ9TC5lKcmLZImOZ/BTSWJeVbay7XK2nlzvFALW3BA5OkvBnbs0poku4EsRpDMndDVnM58EU/8D3ZcoVehWg==",
+      "requires": {
+        "hoek": "4.x.x"
+      }
     },
     "tough-cookie": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@financial-times/n-user-api-client": "4.1.1",
+    "@financial-times/n-user-api-client": "4.1.2",
     "classnames": "^2.2.6",
     "isomorphic-fetch": "3.0.0",
     "react": "^16.12.0"


### PR DESCRIPTION
The latest version of this module was preventing next-control-centre from being able to start because of a missing dependency. This was fixed in n-user-api-client and we need to also bump it here.

Helps resolve [CPREL-518](https://financialtimes.atlassian.net/browse/CPREL-518)

[CPREL-518]: https://financialtimes.atlassian.net/browse/CPREL-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ