### PR TITLE
ACQ-2216: adding default "no" value to Consent & ConsentLite input checkbox fields

### DIFF
--- a/src/js/helpers.ts
+++ b/src/js/helpers.ts
@@ -123,6 +123,20 @@ export function validateConsent(
 	return true;
 }
 
+/**
+ * Recieves a string (or array of stings) value that indicates if the consent was checked or not
+ * and converts to "status" (boolean) value
+ * Posible values: 'yes', 'no', ['yes', 'no']
+ * ACQ-2216: side effect when adding a hidden input field to cover unchecked checkbox
+ */
+function convertStringConsentToBoolean(value) {
+	if (Array.isArray(value)) {
+		return Array.from(value).includes('yes');
+	}
+
+	return value === 'yes';
+}
+
 export function buildConsentRecord(
 	fow: string | FowAPI.Fow | null,
 	keyedConsents: ConsentModelData.KeyedValues,
@@ -133,6 +147,7 @@ export function buildConsentRecord(
 	// and keyedConsents:
 	// {
 	// 	lbi-categoryName-channelName: 'yes',
+	//  lbi-otherCategoryName-channelName: ['yes', 'no'] <-- ACQ-2216: side effect when adding a hidden input field to cover unchecked checkbox
 	// 	consent-categoryName-channelName: 'no'
 	// }
 
@@ -157,7 +172,7 @@ export function buildConsentRecord(
 				consentRecord = consentRecord || {};
 				consentRecord[category] = consentRecord[category] || {};
 				consentRecord[category][channel] = {
-					status: value === 'yes',
+					status: convertStringConsentToBoolean(value),
 					lbi,
 					source,
 					fow: fowId

--- a/src/js/helpers.ts
+++ b/src/js/helpers.ts
@@ -129,9 +129,9 @@ export function validateConsent(
  * Posible values: 'yes', 'no', ['yes', 'no']
  * ACQ-2216: side effect when adding a hidden input field to cover unchecked checkbox
  */
-function convertStringConsentToBoolean(value) {
+function getConsentStatus(value) {
 	if (Array.isArray(value)) {
-		return Array.from(value).includes('yes');
+		return value.includes('yes');
 	}
 
 	return value === 'yes';
@@ -172,7 +172,7 @@ export function buildConsentRecord(
 				consentRecord = consentRecord || {};
 				consentRecord[category] = consentRecord[category] || {};
 				consentRecord[category][channel] = {
-					status: convertStringConsentToBoolean(value),
+					status: getConsentStatus(value),
 					lbi,
 					source,
 					fow: fowId

--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -8,6 +8,7 @@ import {
 	YesNoSwitch,
 } from './';
 import { FowAPI } from '../../types/fow-api';
+import ToggleSwitch from './ToggleSwitch';
 
 interface Props {
 	showHeading: boolean;
@@ -15,7 +16,6 @@ interface Props {
 	isSubsection: boolean;
 	showToggleSwitch: boolean;
 	formOfWords: FowAPI.Fow;
-	includeUncheckedValues: boolean;
 }
 
 const formFieldsClassName = (showToggleSwitch) => {
@@ -35,43 +35,12 @@ const ChannelHeading = ({ heading, isSubsection, showToggleSwitch }) => {
 	return <h2 className="consent-form__heading-level-3">{heading}</h2>;
 };
 
-const ToggleSwitch = ({ lbi, label, category, channel, includeUncheckedValue }) => {
-	const inputName = `${lbi ? 'lbi' : 'consent'}-${category}-${channel}`;
-
-	return (
-		<label id={`${category}-${channel}`}>
-			<input
-				id={`input-${category}-${channel}`}
-				aria-labelledby={`${category}-${channel}`}
-				name={inputName}
-				type="checkbox"
-				value="yes"
-				defaultChecked
-			/>
-			<span
-				className="o-forms-input__label"
-				aria-labelledby={`${category}-${channel}`}>
-					{label}
-			</span>
-			{includeUncheckedValue && (
-				<input
-					id={`input-${category}-${channel}_hidden`}
-					type="hidden"
-					name={inputName}
-					value="no"
-				/>
-			)}
-		</label>
-	);
-};
-
 const Consent = ({
 	showHeading,
 	isSubsection,
 	formOfWords,
 	showSubmitButton,
 	showToggleSwitch,
-	includeUncheckedValues,
 }: Props) => (
 	<>
 		{showHeading && formOfWords.copy && (
@@ -120,7 +89,6 @@ const Consent = ({
 											key={category}
 											label={label}
 											category={category}
-											includeUncheckedValue={includeUncheckedValues}
 											{...rest}
 										/>
 									) : (

--- a/src/js/server/components/Consent.tsx
+++ b/src/js/server/components/Consent.tsx
@@ -15,6 +15,7 @@ interface Props {
 	isSubsection: boolean;
 	showToggleSwitch: boolean;
 	formOfWords: FowAPI.Fow;
+	includeUncheckedValues: boolean;
 }
 
 const formFieldsClassName = (showToggleSwitch) => {
@@ -34,13 +35,15 @@ const ChannelHeading = ({ heading, isSubsection, showToggleSwitch }) => {
 	return <h2 className="consent-form__heading-level-3">{heading}</h2>;
 };
 
-const ToggleSwitch = ({ lbi, label, category, channel }) => {
+const ToggleSwitch = ({ lbi, label, category, channel, includeUncheckedValue }) => {
+	const inputName = `${lbi ? 'lbi' : 'consent'}-${category}-${channel}`;
+
 	return (
 		<label id={`${category}-${channel}`}>
 			<input
 				id={`input-${category}-${channel}`}
 				aria-labelledby={`${category}-${channel}`}
-				name={`${lbi ? 'lbi' : 'consent'}-${category}-${channel}`}
+				name={inputName}
 				type="checkbox"
 				value="yes"
 				defaultChecked
@@ -50,6 +53,14 @@ const ToggleSwitch = ({ lbi, label, category, channel }) => {
 				aria-labelledby={`${category}-${channel}`}>
 					{label}
 			</span>
+			{includeUncheckedValue && (
+				<input
+					id={`input-${category}-${channel}_hidden`}
+					type="hidden"
+					name={inputName}
+					value="no"
+				/>
+			)}
 		</label>
 	);
 };
@@ -60,6 +71,7 @@ const Consent = ({
 	formOfWords,
 	showSubmitButton,
 	showToggleSwitch,
+	includeUncheckedValues,
 }: Props) => (
 	<>
 		{showHeading && formOfWords.copy && (
@@ -108,6 +120,7 @@ const Consent = ({
 											key={category}
 											label={label}
 											category={category}
+											includeUncheckedValue={includeUncheckedValues}
 											{...rest}
 										/>
 									) : (

--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { ConsentHeading, FOWHiddenInputs } from './';
 import { FowAPI } from '../../types/fow-api';
+import ToggleSwitch from './ToggleSwitch';
 
 interface Props {
 	showToggleSwitch: boolean;
@@ -13,7 +14,6 @@ interface Props {
 	formOfWords: FowAPI.Fow;
 	label: string;
 	showFooter: boolean;
-	includeUncheckedValues: boolean;
 }
 
 const formsFieldClassName = (showToggleSwitch) => {
@@ -25,7 +25,6 @@ const formsFieldClassName = (showToggleSwitch) => {
 const ConsentFields = ({
 	formOfWords,
 	showToggleSwitch,
-	includeUncheckedValues,
 }) => (
 	<div className="consent-form__section-wrapper">
 		<div className="o-forms-field">
@@ -38,14 +37,12 @@ const ConsentFields = ({
 								label={label}
 								heading={heading}
 								category={category}
-								includeUncheckedValue={includeUncheckedValues}
 							/>
 						) : (
 							<CheckBox
 								key={category}
 								label={label}
 								category={category}
-								includeUncheckedValue={includeUncheckedValues}
 							/>
 						);
 					})}
@@ -54,35 +51,7 @@ const ConsentFields = ({
 	</div>
 );
 
-const ToggleSwitch = ({ label, category, heading, includeUncheckedValue }) => {
-	const inputName = `consent-${category}-byEmail`;
-
-	return (
-		<label>
-			<input
-				id={`${category}-toggleSwitch`}
-				type="checkbox"
-				name={inputName}
-				value="yes"
-				defaultChecked
-			/>
-			<span className="o-forms-input__label">
-				<span className="o-forms-input__label__main">{heading}</span>
-				<span className="o-forms-input__label__prompt">{label}</span>
-			</span>
-			{includeUncheckedValue && (
-				<input
-					id={`${category}-toggleSwitch_hidden`}
-					type="hidden"
-					name={inputName}
-					value="no"
-				/>
-			)}
-		</label>
-	);
-};
-
-const CheckBox = ({ label, category, includeUncheckedValue }) => {
+const CheckBox = ({ label, category }) => {
 	const inputName = `consent-${category}-byEmail`;
 
 	return (
@@ -95,14 +64,12 @@ const CheckBox = ({ label, category, includeUncheckedValue }) => {
 				defaultChecked
 			/>
 			<span className="o-forms-input__label">{label}</span>
-			{includeUncheckedValue && (
-				<input
-					id={`${category}_hidden`}
-					type="hidden"
-					name={inputName}
-					value="no"
-				/>
-			)}
+			<input
+				id={`${category}_hidden`}
+				type="hidden"
+				name={inputName}
+				value="no"
+			/>
 		</label>
 	);
 };
@@ -196,7 +163,6 @@ const ConsentLite = ({
 	formOfWords,
 	showSubmitButton,
 	showFooter = true,
-	includeUncheckedValues = false,
 }: Props) => (
 	<>
 		{showHeading && formOfWords.copy && (
@@ -224,7 +190,6 @@ const ConsentLite = ({
 			<ConsentFields
 				formOfWords={formOfWords}
 				showToggleSwitch={showToggleSwitch || false}
-				includeUncheckedValues={includeUncheckedValues}
 			/>
 			{!showToggleSwitch && <MoreInfo formOfWords={formOfWords} />}
 			{showSubmitButton && <SubmitButton formOfWords={formOfWords} />}

--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -37,6 +37,7 @@ const ConsentFields = ({
 								label={label}
 								heading={heading}
 								category={category}
+								isLite={true}
 							/>
 						) : (
 							<CheckBox

--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -13,6 +13,7 @@ interface Props {
 	formOfWords: FowAPI.Fow;
 	label: string;
 	showFooter: boolean;
+	includeUncheckedValues: boolean;
 }
 
 const formsFieldClassName = (showToggleSwitch) => {
@@ -21,7 +22,11 @@ const formsFieldClassName = (showToggleSwitch) => {
 		: 'o-forms-input o-forms-input--checkbox';
 };
 
-const ConsentFields = ({ formOfWords, showToggleSwitch }) => (
+const ConsentFields = ({
+	formOfWords,
+	showToggleSwitch,
+	includeUncheckedValues,
+}) => (
 	<div className="consent-form__section-wrapper">
 		<div className="o-forms-field">
 			<span className={`${formsFieldClassName(showToggleSwitch)}`}>
@@ -33,9 +38,15 @@ const ConsentFields = ({ formOfWords, showToggleSwitch }) => (
 								label={label}
 								heading={heading}
 								category={category}
+								includeUncheckedValue={includeUncheckedValues}
 							/>
 						) : (
-							<CheckBox key={category} label={label} category={category} />
+							<CheckBox
+								key={category}
+								label={label}
+								category={category}
+								includeUncheckedValue={includeUncheckedValues}
+							/>
 						);
 					})}
 			</span>
@@ -43,13 +54,15 @@ const ConsentFields = ({ formOfWords, showToggleSwitch }) => (
 	</div>
 );
 
-const ToggleSwitch = ({ label, category, heading }) => {
+const ToggleSwitch = ({ label, category, heading, includeUncheckedValue }) => {
+	const inputName = `consent-${category}-byEmail`;
+
 	return (
 		<label>
 			<input
 				id={`${category}-toggleSwitch`}
 				type="checkbox"
-				name={`consent-${category}-byEmail`}
+				name={inputName}
 				value="yes"
 				defaultChecked
 			/>
@@ -57,21 +70,39 @@ const ToggleSwitch = ({ label, category, heading }) => {
 				<span className="o-forms-input__label__main">{heading}</span>
 				<span className="o-forms-input__label__prompt">{label}</span>
 			</span>
+			{includeUncheckedValue && (
+				<input
+					id={`${category}-toggleSwitch_hidden`}
+					type="hidden"
+					name={inputName}
+					value="no"
+				/>
+			)}
 		</label>
 	);
 };
 
-const CheckBox = ({ label, category }) => {
+const CheckBox = ({ label, category, includeUncheckedValue }) => {
+	const inputName = `consent-${category}-byEmail`;
+
 	return (
 		<label htmlFor={category}>
 			<input
 				id={category}
 				type="checkbox"
-				name={`consent-${category}-byEmail`}
+				name={inputName}
 				value="yes"
 				defaultChecked
 			/>
 			<span className="o-forms-input__label">{label}</span>
+			{includeUncheckedValue && (
+				<input
+					id={`${category}_hidden`}
+					type="hidden"
+					name={inputName}
+					value="no"
+				/>
+			)}
 		</label>
 	);
 };
@@ -165,6 +196,7 @@ const ConsentLite = ({
 	formOfWords,
 	showSubmitButton,
 	showFooter = true,
+	includeUncheckedValues = false,
 }: Props) => (
 	<>
 		{showHeading && formOfWords.copy && (
@@ -192,6 +224,7 @@ const ConsentLite = ({
 			<ConsentFields
 				formOfWords={formOfWords}
 				showToggleSwitch={showToggleSwitch || false}
+				includeUncheckedValues={includeUncheckedValues}
 			/>
 			{!showToggleSwitch && <MoreInfo formOfWords={formOfWords} />}
 			{showSubmitButton && <SubmitButton formOfWords={formOfWords} />}

--- a/src/js/server/components/Overlay.tsx
+++ b/src/js/server/components/Overlay.tsx
@@ -21,7 +21,6 @@ const Overlay = ({ formOfWords }: Props) => (
 						isSubsection={false}
 						formOfWords={formOfWords}
 						showToggleSwitch={false}
-						includeUncheckedValues={false}
 					/>
 				</form>
 				<div className="consent-confirmation hidden">

--- a/src/js/server/components/Overlay.tsx
+++ b/src/js/server/components/Overlay.tsx
@@ -21,6 +21,7 @@ const Overlay = ({ formOfWords }: Props) => (
 						isSubsection={false}
 						formOfWords={formOfWords}
 						showToggleSwitch={false}
+						includeUncheckedValues={false}
 					/>
 				</form>
 				<div className="consent-confirmation hidden">

--- a/src/js/server/components/ToggleSwitch.tsx
+++ b/src/js/server/components/ToggleSwitch.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+interface Props {
+	lbi?: boolean;
+	label: string;
+	category: string;
+	channel?: string;
+	isLite?: boolean;
+	heading?: string;
+}
+
+const ToggleSwitch = ({
+	lbi,
+	label,
+	category,
+	isLite = false,
+	channel = 'byEmail',
+	heading,
+}: Props) => {
+	const inputId = isLite
+		? `${category}-toggleSwitch`
+		: `input-${category}-${channel}`;
+	const inputName = `${lbi ? 'lbi' : 'consent'}-${category}-${channel}`;
+	const consentLabel = isLite ? (
+		<>
+			<span className="o-forms-input__label__main">{heading}</span>
+			<span className="o-forms-input__label__prompt">{label}</span>
+		</>
+	) : (
+		label
+	);
+
+	return (
+		<label id={`${category}-${channel}`}>
+			<input
+				id={inputId}
+				aria-labelledby={`${category}-${channel}`}
+				name={inputName}
+				type="checkbox"
+				value="yes"
+				defaultChecked
+			/>
+			<span
+				className="o-forms-input__label"
+				aria-labelledby={`${category}-${channel}`}
+			>
+				{consentLabel}
+			</span>
+			<input
+				id={`${inputId}_hidden`}
+				type="hidden"
+				name={inputName}
+				value="no"
+			/>
+		</label>
+	);
+};
+
+export default ToggleSwitch;

--- a/src/js/types/helpers.d.ts
+++ b/src/js/types/helpers.d.ts
@@ -14,6 +14,6 @@ export namespace ConsentModelData {
 	}
 
 	export interface KeyedValues {
-		[name: string]: string;
+		[name: string]: string | string[];
 	}
 }

--- a/test/unit/helpers.spec.ts
+++ b/test/unit/helpers.spec.ts
@@ -128,7 +128,7 @@ describe('helper functions', () => {
 		const consentFields = {
 			'lbi-categoryA-channel1': 'no',
 			'lbi-categoryB-channel1': 'yes',
-			'consent-categoryB-channel2': 'yes',
+			'consent-categoryB-channel2': ['yes', 'no'],
 		};
 		const expectedResult = clone(fixtures.consentRecord);
 		delete expectedResult.categoryA.channel1.lastModified;


### PR DESCRIPTION
## Description

Some time ago, consent components (`Consent` and `ConsentLite`) had been modified to move from html `radio-button` to `checkbox` input fields.

### The Problem

If a checkbox is unchecked when its form is submitted, neither the name nor the value is submitted to the server.
Currently, all repos using `Consent` and `ConsentLite` are not receiving the "no" value when they are unchecked. That means that the unchecked consents are not sent through the Consent API and then FT doesn't know if the consents were presented to the user (only the checked consents are sent today).


In addition, when all consents in the page are unchecked, then the server is throwing an error when calling [buildConsentRecord](https://github.com/Financial-Times/n-profile-ui/blob/v14.1.2/src/js/helpers.ts#LL126C17-L126C35) method because no consents are found in the body request.

```Javascript
  if (!consentRecord) {
    throw new Error('Found no valid consents');
  }
```
See https://financialtimes.atlassian.net/browse/ACQ-2204 for examples.

### The Solution

The solution proposed by this PR is to create a `<input type="hidden">` within the form with a value indicating an unchecked state, using the same "name" property to ensure receiving a default "no" value when the checkbox is unchecked.

The side effect is that the server side is receiving an array of value instead of a single string only when the checkbox is checked.

Example:
- consent-enhancement-byEmail --> checked ✅ 
- consent-marketing-byEmail --> unchecked 🔲 

![image](https://github.com/Financial-Times/n-profile-ui/assets/13876273/770c8aa0-a066-48a5-b7f7-04c256c3c551)

Please notice that `buildConsentRecord` method is also modified to handle both cases: string or array of string values, looking for `yes` occurrences.

As an extra, ToggleSwitch was extracted from `Consent` and `ConsentLite` to a new separated component to be reusable.

## Ticket
- https://financialtimes.atlassian.net/browse/ACQ-2204
- https://financialtimes.atlassian.net/browse/ACQ-2216

