### PR TITLE
ACQ-2273: Errors when trying to add the consents shown to the user into the tracking context

### DIFF
--- a/src/js/client/consent.ts
+++ b/src/js/client/consent.ts
@@ -58,6 +58,14 @@ export class ConsentForm {
 		);
 	}
 
+	protected getCheckboxes(checked?: boolean): Array<HTMLInputElement> {
+		return Array.from(
+			this.element.querySelectorAll(
+				`.consent-form__section input[type=checkbox]${checked ? ':checked' : ''}`
+			)
+		);
+	}
+
 	protected consentFromRadio(radio: HTMLInputElement): ConsentAPI.Record {
 		const consentObject = { [radio.name]: radio.value };
 		return buildConsentRecord(this.fow, consentObject, this.source);

--- a/src/js/client/consent.ts
+++ b/src/js/client/consent.ts
@@ -17,6 +17,7 @@ export class ConsentForm {
 	public source: string;
 	public submitButton: HTMLButtonElement | null;
 	public radios: Array<HTMLInputElement>;
+	public checkboxes: Array<HTMLInputElement>;
 	protected options: ConsentOptions;
 
 	constructor(opts: ConsentOptions) {
@@ -40,6 +41,7 @@ export class ConsentForm {
 
 		this.scope = this.getValue('formOfWordsScope') || 'FTPINK';
 		this.radios = this.getRadios();
+		this.checkboxes = this.getCheckboxes();
 
 		this.submitButton = this.element.querySelector('.consent-form__submit');
 		this.options = opts;
@@ -58,10 +60,10 @@ export class ConsentForm {
 		);
 	}
 
-	protected getCheckboxes(checked?: boolean): Array<HTMLInputElement> {
+	protected getCheckboxes(): Array<HTMLInputElement> {
 		return Array.from(
 			this.element.querySelectorAll(
-				`.consent-form__section input[type=checkbox]${checked ? ':checked' : ''}`
+				`.consent-form__section input[type=checkbox]`
 			)
 		);
 	}

--- a/src/js/client/update-on-save.ts
+++ b/src/js/client/update-on-save.ts
@@ -17,6 +17,16 @@ export class UpdateConsentOnSave extends ConsentForm {
 		radios.forEach((radio: HTMLInputElement) => {
 			consentObject[radio.name] = radio.value;
 		});
+		
+		const checkboxes = this.getCheckboxes();
+
+		checkboxes.forEach((checkbox: HTMLInputElement) => {
+			consentObject[checkbox.name] = checkbox.checked ? 'yes' : 'no';
+		});
+
+		console.log(checkboxes)
+		console.log(consentObject)
+
 
 		return buildConsentRecord(this.fow, consentObject, this.source);
 	}

--- a/src/js/client/update-on-save.ts
+++ b/src/js/client/update-on-save.ts
@@ -24,10 +24,6 @@ export class UpdateConsentOnSave extends ConsentForm {
 			consentObject[checkbox.name] = checkbox.checked ? 'yes' : 'no';
 		});
 
-		console.log(checkboxes)
-		console.log(consentObject)
-
-
 		return buildConsentRecord(this.fow, consentObject, this.source);
 	}
 

--- a/test/client/update-on-save.spec.ts
+++ b/test/client/update-on-save.spec.ts
@@ -1,0 +1,67 @@
+import { UpdateConsentOnSave } from '../../src/js/client/update-on-save';
+import * as sinon from 'sinon';
+import { JSDOM } from 'jsdom';
+const formOfWords = require('../fixtures/form-of-words.json');
+import { loadHTML } from './helpers/load-html';
+
+describe('helper functions', () => {
+	beforeEach(() => {
+		document.body.innerHTML = loadHTML({
+			formOfWords: { ...formOfWords, source: 'test' },
+			showToggleSwitch: true,
+		});
+	});
+
+	it('test_radio_and_checkbox_values', () => {
+		const form = new UpdateConsentOnSave({
+			selector: '.js-consent-preference',
+		});
+
+		const consentRecord = form.values;
+		expect(consentRecord).toEqual({
+			categoryA: {
+				channel1: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+                    
+				},
+                channel2: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+				},
+                channel3: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+				},
+			},
+			categoryB: {
+                channel1: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+                    
+				},
+				channel2: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+				},
+                channel3: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+                    
+				},
+			},
+		});
+	});
+});

--- a/test/client/update-on-save.spec.ts
+++ b/test/client/update-on-save.spec.ts
@@ -1,6 +1,4 @@
 import { UpdateConsentOnSave } from '../../src/js/client/update-on-save';
-import * as sinon from 'sinon';
-import { JSDOM } from 'jsdom';
 const formOfWords = require('../fixtures/form-of-words.json');
 import { loadHTML } from './helpers/load-html';
 
@@ -25,28 +23,6 @@ describe('helper functions', () => {
 					lbi: false,
 					source: 'test',
 					fow: 'testFow/testVersion',
-                    
-				},
-                channel2: {
-					status: true,
-					lbi: false,
-					source: 'test',
-					fow: 'testFow/testVersion',
-				},
-                channel3: {
-					status: true,
-					lbi: false,
-					source: 'test',
-					fow: 'testFow/testVersion',
-				},
-			},
-			categoryB: {
-                channel1: {
-					status: true,
-					lbi: false,
-					source: 'test',
-					fow: 'testFow/testVersion',
-                    
 				},
 				channel2: {
 					status: true,
@@ -54,12 +30,31 @@ describe('helper functions', () => {
 					source: 'test',
 					fow: 'testFow/testVersion',
 				},
-                channel3: {
+				channel3: {
 					status: true,
 					lbi: false,
 					source: 'test',
 					fow: 'testFow/testVersion',
-                    
+				},
+			},
+			categoryB: {
+				channel1: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+				},
+				channel2: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
+				},
+				channel3: {
+					status: true,
+					lbi: false,
+					source: 'test',
+					fow: 'testFow/testVersion',
 				},
 			},
 		});


### PR DESCRIPTION
### Info
There is an error on client side when landing on /buy/offer/{offerId}/preferences page that prevents attach to the tracking context (later sent to spoor API) the consents shown to the user.

The code is using a n-profile-ui helper function that is still trying to get radio buttons instead of checkboxes.

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2273

### Screenshot
<img width="1512" alt="Screenshot 2023-07-17 at 18 21 13" src="https://github.com/Financial-Times/n-profile-ui/assets/133669966/7f220e00-208d-4928-ba22-04ed24692d89">
