### PR TITLE
ADSDEV-1700: Ensure correct assets are published

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "UI components for profile / consent",
   "main": "./dist/server/main.js",
   "browser": "./dist/client/main.js",
-  "files": ["main.scss", "src/scss/", "dist/"],
+  "files": ["main.scss", "src/scss/", "templates/", "dist/"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Financial-Times/n-profile-ui.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "UI components for profile / consent",
   "main": "./dist/server/main.js",
   "browser": "./dist/client/main.js",
-  "files": ["*"],
+  "files": ["main.scss", "src/scss/", "dist/"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Financial-Times/n-profile-ui.git"


### PR DESCRIPTION
This PR ensures that `dist/`, `templates/`, `main.scss` and `src/scss/` are included in the published module

This beta release demonstrates the expected behaviour:
https://www.npmjs.com/package/@financial-times/n-profile-ui/v/17.1.5-beta.3?activeTab=code

Once accepted we can cut a v17.1.5 release (required by `next-control-centre`)