### PR TITLE
Consent change for US election sign up

### DIFF
--- a/src/js/server/components/ConsentLite.tsx
+++ b/src/js/server/components/ConsentLite.tsx
@@ -111,6 +111,21 @@ const MoreInfo = ({ formOfWords }) => {
 					&nbsp;apply.&nbsp;{defaultMoreInfo({ display: 'inline' })}
 				</div>
 			);
+			case 'inArticleSignUpUSElection':
+				return (
+					<div className="consent-form__consent-info-para">
+						By signing up for this email, you're registering for a free account
+						with the FT. Full
+						<a
+							className="consent-form__link--external"
+							href="http://help.ft.com/help/legal-privacy/terms-conditions/"
+							target="_blank"
+						>
+							&nbsp;Terms and Conditions
+						</a>
+						&nbsp;apply.&nbsp;{defaultMoreInfo({ display: 'inline' })}
+					</div>
+				);
 		default:
 			return defaultMoreInfo({});
 	}


### PR DESCRIPTION
### Summary
We (acquisition team) are working on the new feature of in-article sign up for US Newsletter. Consent box wording for this signup experience needs to be changed. 
![image](https://github.com/Financial-Times/n-profile-ui/assets/133233790/98f79ecc-1d1d-4692-8796-7d06da5bd4ca)

Highlighted line needs to be removed as we will only be signing use up for US election newsletter and not the Editor's Digest one.

### Epic link
https://financialtimes.atlassian.net/browse/ACQ-2702

### Code change
I have added `inArticleSignUpUSElection` in the custom info to handle this case. 
`next-subscribe` PR - https://github.com/Financial-Times/next-subscribe/pull/2864

